### PR TITLE
[codex] Add debugger bridge and runtime probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ A powerful Godot Engine plugin that integrates AI assistants (Claude, etc.) via 
 - **Full Project Access**: AI assistants can read and modify scripts, scenes, nodes, and resources
 - **Native Implementation**: No Node.js dependency required - runs entirely within Godot
 - **Real-time Editing**: Apply AI suggestions directly in the editor
-- **Comprehensive Tool Set** (50+ tools):
+- **Comprehensive Tool Set** (62 tools):
   - **Node Tools** (16): Create, modify, manage scene nodes, duplicate, move, rename, signal connections, group management
   - **Script Tools** (9): Edit, analyze, create, attach, validate GDScript files, search in files
   - **Scene Tools** (6): Manipulate scene structure and save scenes
   - **Editor Tools** (8): Control editor functionality, screenshot, signal inspection, filesystem reload
-  - **Debug Tools** (6): Debugging, logging, log clearing, script execution
+  - **Debug Tools** (18): Logging, script execution, debugger sessions, breakpoints, stack/variable inspection, profilers, runtime probe
   - **Project Tools** (5): Access project settings and list resources
 
 ## 📦 Installation
@@ -122,13 +122,16 @@ Implement a day/night cycle system with dynamic lighting
 - `set-node-groups` - Set group memberships for a node
 - `find-nodes-in-group` - Find all nodes in a specific group
 
-### Script Tools (6)
+### Script Tools (9)
 - `list-project-scripts` - List all scripts
 - `read-script` - Read a specific script
 - `modify-script` - Update script content
 - `create-script` - Create a new script
 - `analyze-script` - Analyze script structure
 - `get-current-script` - Get currently editing script
+- `attach-script` - Attach an existing script to a node
+- `validate-script` - Validate GDScript syntax
+- `search-in-files` - Search project files
 
 ### Scene Tools (6)
 - `list-project-scenes` - List all scenes
@@ -145,19 +148,35 @@ Implement a day/night cycle system with dynamic lighting
 - `create-resource` - Create a new resource
 - `get-project-structure` - Get project directory structure
 
-### Editor Tools (5)
+### Editor Tools (8)
 - `get-editor-state` - Get current editor state
 - `run-project` - Run the project
 - `stop-project` - Stop the running project
 - `get-selected-nodes` - Get selected nodes
 - `set-editor-setting` - Modify editor settings
+- `get-editor-screenshot` - Capture an editor viewport screenshot
+- `get-signals` - Inspect node signals and connections
+- `reload-project` - Rescan the project filesystem
 
-### Debug Tools (5)
+### Debug Tools (18)
 - `get-editor-logs` - Get editor/runtime logs
 - `execute-script` - Execute GDScript expression
 - `get-performance-metrics` - Get performance data
 - `debug-print` - Print debug info
 - `execute-editor-script` - Execute GDScript script
+- `clear-output` - Clear MCP/editor output buffers
+- `get-debugger-sessions` - List editor debugger sessions and active/break state
+- `set-debugger-breakpoint` - Enable or disable debugger breakpoints
+- `send-debugger-message` - Send custom messages to the running game debugger
+- `toggle-debugger-profiler` - Toggle EngineProfiler channels in active sessions
+- `get-debugger-messages` - Read custom runtime messages captured by the bridge
+- `add-debugger-capture-prefix` - Capture additional EngineDebugger message prefixes
+- `get-debug-stack-frames` - Read captured script stack frames from a breaked session
+- `get-debug-stack-variables` - Read locals, members, and globals for a captured stack frame
+- `install-runtime-probe` - Add the MCP runtime probe node to the current scene
+- `remove-runtime-probe` - Remove the MCP runtime probe node from the current scene
+- `request-debug-break` - Ask the runtime probe to enter Godot's debug break loop
+- `send-debug-command` - Send step/next/out/continue/stack debugger commands to breaked sessions
 
 ## 🔒 Security Recommendations
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,12 +13,12 @@
 - **完整项目访问**：AI 助手可以读取和修改脚本、场景、节点和资源
 - **原生实现**：无需 Node.js 依赖——完全在 Godot 中运行
 - **实时编辑**：直接在编辑器中应用 AI 建议
-- **全面的工具集**（50+ 工具）：
+- **全面的工具集**（62 个工具）：
   - **节点工具**（16 个）：创建、修改、管理场景节点，复制、移动、重命名，信号连接，组管理
   - **脚本工具**（9 个）：编辑、分析、创建、附加、验证 GDScript 文件，文件搜索
   - **场景工具**（6 个）：操作场景结构并保存场景
   - **编辑器工具**（8 个）：控制编辑器功能、截图、信号检查、文件系统重载
-  - **调试工具**（6 个）：调试、日志记录、日志清除、脚本执行
+  - **调试工具**（18 个）：日志、脚本执行、调试会话、断点、栈帧/变量读取、性能分析器、运行时探针
   - **项目工具**（5 个）：访问项目设置和列出资源
 
 ## 📦 安装
@@ -124,13 +124,16 @@
 - `set-node-groups` - 设置节点的组成员关系
 - `find-nodes-in-group` - 查找组中的所有节点
 
-### 脚本工具 (6)
+### 脚本工具 (9)
 - `list-project-scripts` - 列出所有脚本
 - `read-script` - 读取特定脚本
 - `modify-script` - 更新脚本内容
 - `create-script` - 创建新脚本
 - `analyze-script` - 分析脚本结构
 - `get-current-script` - 获取当前正在编辑的脚本
+- `attach-script` - 将已有脚本附加到节点
+- `validate-script` - 验证 GDScript 语法
+- `search-in-files` - 搜索项目文件
 
 ### 场景工具 (6)
 - `list-project-scenes` - 列出所有场景
@@ -147,19 +150,35 @@
 - `create-resource` - 创建新资源
 - `get-project-structure` - 获取项目目录结构
 
-### 编辑器工具 (5)
+### 编辑器工具 (8)
 - `get-editor-state` - 获取当前编辑器状态
 - `run-project` - 运行项目
 - `stop-project` - 停止运行中的项目
 - `get-selected-nodes` - 获取选中的节点
 - `set-editor-setting` - 修改编辑器设置
+- `get-editor-screenshot` - 截取编辑器视口截图
+- `get-signals` - 检查节点信号和连接
+- `reload-project` - 重新扫描项目文件系统
 
-### 调试工具 (5)
+### 调试工具 (18)
 - `get-editor-logs` - 获取编辑器/运行时日志
 - `execute-script` - 执行 GDScript 表达式
 - `get-performance-metrics` - 获取性能数据
 - `debug-print` - 打印调试信息
 - `execute-editor-script` - 执行 GDScript 脚本
+- `clear-output` - 清除 MCP/编辑器输出缓冲
+- `get-debugger-sessions` - 列出编辑器调试会话和 active/break 状态
+- `set-debugger-breakpoint` - 启用或禁用调试断点
+- `send-debugger-message` - 向运行中的游戏调试器发送自定义消息
+- `toggle-debugger-profiler` - 在活动会话中切换 EngineProfiler 通道
+- `get-debugger-messages` - 读取 bridge 捕获的运行时自定义消息
+- `add-debugger-capture-prefix` - 捕获更多 EngineDebugger 消息前缀
+- `get-debug-stack-frames` - 读取已暂停会话捕获到的脚本栈帧
+- `get-debug-stack-variables` - 读取指定栈帧的局部变量、成员变量和全局变量
+- `install-runtime-probe` - 向当前场景添加 MCP 运行时探针节点
+- `remove-runtime-probe` - 从当前场景移除 MCP 运行时探针节点
+- `request-debug-break` - 请求运行时探针进入 Godot 调试暂停循环
+- `send-debug-command` - 向已暂停会话发送 step/next/out/continue/stack 调试命令
 
 ## 🔒 安全建议
 

--- a/addons/godot_mcp/mcp_server_native.gd
+++ b/addons/godot_mcp/mcp_server_native.gd
@@ -92,6 +92,7 @@ var _main_panel: Control = null
 var _editor_interface: EditorInterface = null
 var _mcp_server_mode: bool = false
 var _tool_instances: Dictionary = {}
+var _debugger_bridge: MCPDebuggerBridge = null
 
 # ============================================================================
 # 生命周期方法
@@ -112,6 +113,9 @@ func _enter_tree() -> void:
 	if not _native_server:
 		_log_error("Failed to create MCP Server Core instance")
 		return
+
+	_debugger_bridge = MCPDebuggerBridge.new()
+	add_debugger_plugin(_debugger_bridge)
 	
 	# 设置传输方式
 	var type: int = MCPServerCore.TransportType.TRANSPORT_STDIO if transport_mode == "stdio" \
@@ -189,6 +193,10 @@ func _exit_tree() -> void:
 		EditorInterface.get_editor_main_screen().remove_child(_main_panel)
 		_main_panel.queue_free()
 		_main_panel = null
+
+	if _debugger_bridge:
+		remove_debugger_plugin(_debugger_bridge)
+		_debugger_bridge = null
 	
 	_native_server = null
 	
@@ -213,6 +221,9 @@ func _get_plugin_icon() -> Texture2D:
 
 func get_native_server() -> RefCounted:
 	return _native_server
+
+func get_debugger_bridge() -> MCPDebuggerBridge:
+	return _debugger_bridge
 
 func _has_settings() -> bool:
 	return true

--- a/addons/godot_mcp/native_mcp/mcp_debugger_bridge.gd
+++ b/addons/godot_mcp/native_mcp/mcp_debugger_bridge.gd
@@ -1,0 +1,192 @@
+@tool
+class_name MCPDebuggerBridge
+extends EditorDebuggerPlugin
+
+var _capture_prefixes: Array[String] = [
+	"mcp",
+	"debug_enter",
+	"debug_exit",
+	"stack_dump",
+	"stack_frame_vars",
+	"stack_frame_var",
+	"output",
+	"error"
+]
+var _captured_messages: Array[Dictionary] = []
+var _max_messages: int = 500
+var _connected_script_debuggers: Array[Object] = []
+var _latest_stack_dump: Array = []
+var _latest_stack_variables: Dictionary = {}
+var _pending_stack_vars_frame: int = 0
+
+func _setup_session(session_id: int) -> void:
+	call_deferred("_refresh_script_debugger_connections")
+
+func _has_capture(capture: String) -> bool:
+	return _capture_prefixes.has("*") or _capture_prefixes.has(capture)
+
+func _capture(message: String, data: Array, session_id: int) -> bool:
+	_append_captured_message(session_id, message, data)
+	return true
+
+func add_capture_prefix(prefix: String) -> void:
+	if prefix.is_empty() or _capture_prefixes.has(prefix):
+		return
+	_capture_prefixes.append(prefix)
+
+func get_sessions_info() -> Array[Dictionary]:
+	_refresh_script_debugger_connections()
+	var result: Array[Dictionary] = []
+	var sessions: Array = get_sessions()
+	for index in range(sessions.size()):
+		var session: EditorDebuggerSession = sessions[index]
+		if not session:
+			continue
+		result.append({
+			"session_id": index,
+			"active": session.is_active(),
+			"breaked": session.is_breaked(),
+			"debuggable": session.is_debuggable()
+		})
+	return result
+
+func set_breakpoint(path: String, line: int, enabled: bool, session_id: int = -1) -> Dictionary:
+	return _for_each_session(session_id, func(session: EditorDebuggerSession) -> void:
+		session.set_breakpoint(path, line, enabled)
+	)
+
+func send_debugger_message(message: String, data: Array, session_id: int = -1) -> Dictionary:
+	_refresh_script_debugger_connections()
+	var action: Callable = func(session: EditorDebuggerSession) -> void:
+		session.send_message(message, data)
+	return _for_each_session(session_id, action, true)
+
+func request_stack_dump(session_id: int = -1) -> Dictionary:
+	_refresh_script_debugger_connections()
+	return send_debugger_message("get_stack_dump", [], session_id)
+
+func request_stack_frame_vars(frame: int = 0, session_id: int = -1) -> Dictionary:
+	_refresh_script_debugger_connections()
+	_pending_stack_vars_frame = frame
+	return send_debugger_message("get_stack_frame_vars", [frame], session_id)
+
+func get_latest_stack_dump() -> Array:
+	return _latest_stack_dump.duplicate(true)
+
+func get_latest_stack_variables(frame: int = -1) -> Array:
+	if frame >= 0:
+		return _latest_stack_variables.get(frame, []).duplicate(true)
+	var result: Array = []
+	var frames: Array = _latest_stack_variables.keys()
+	frames.sort()
+	for frame_id in frames:
+		result.append({
+			"frame": frame_id,
+			"variables": _latest_stack_variables[frame_id].duplicate(true)
+		})
+	return result
+
+func toggle_profiler(profiler: String, enabled: bool, data: Array, session_id: int = -1) -> Dictionary:
+	var action: Callable = func(session: EditorDebuggerSession) -> void:
+		session.toggle_profiler(profiler, enabled, data)
+	return _for_each_session(session_id, action, true)
+
+func get_captured_messages(count: int = 100, offset: int = 0, order: String = "desc") -> Dictionary:
+	_refresh_script_debugger_connections()
+	var messages: Array = _captured_messages.duplicate()
+	if order == "desc":
+		messages.reverse()
+	var start: int = clampi(offset, 0, messages.size())
+	var end: int = clampi(start + max(count, 0), start, messages.size())
+	return {
+		"messages": messages.slice(start, end),
+		"count": end - start,
+		"total_available": messages.size()
+	}
+
+func get_capture_prefixes() -> Array[String]:
+	return _capture_prefixes.duplicate()
+
+func _refresh_script_debugger_connections() -> void:
+	var tree: SceneTree = Engine.get_main_loop() as SceneTree
+	if not tree:
+		return
+	var base: Node = tree.root
+	if not base:
+		return
+	var pending: Array[Node] = [base]
+	while not pending.is_empty():
+		var node: Node = pending.pop_back()
+		if node.get_class() == "ScriptEditorDebugger":
+			_connect_script_debugger(node)
+		for child in node.get_children():
+			pending.append(child)
+
+func _connect_script_debugger(debugger: Object) -> void:
+	if _connected_script_debuggers.has(debugger):
+		return
+	if debugger.has_signal("stack_dump"):
+		debugger.connect("stack_dump", Callable(self, "_on_stack_dump"))
+	if debugger.has_signal("stack_frame_vars"):
+		debugger.connect("stack_frame_vars", Callable(self, "_on_stack_frame_vars"))
+	if debugger.has_signal("stack_frame_var"):
+		debugger.connect("stack_frame_var", Callable(self, "_on_stack_frame_var"))
+	_connected_script_debuggers.append(debugger)
+
+func _on_stack_dump(stack: Array) -> void:
+	_latest_stack_dump = stack.duplicate(true)
+	_latest_stack_variables.clear()
+	_append_captured_message(-1, "stack_dump", [stack])
+
+func _on_stack_frame_vars(size: Variant) -> void:
+	_latest_stack_variables[_pending_stack_vars_frame] = []
+	_append_captured_message(-1, "stack_frame_vars", [size])
+
+func _on_stack_frame_var(data: Array) -> void:
+	var variable: Dictionary = _decode_stack_variable(data)
+	if not _latest_stack_variables.has(_pending_stack_vars_frame):
+		_latest_stack_variables[_pending_stack_vars_frame] = []
+	_latest_stack_variables[_pending_stack_vars_frame].append(variable)
+	_append_captured_message(-1, "stack_frame_var", [variable])
+
+func _decode_stack_variable(data: Array) -> Dictionary:
+	var scope_names: Array[String] = ["local", "member", "global", "constant"]
+	var scope_id: int = int(data[1]) if data.size() > 1 else -1
+	return {
+		"name": str(data[0]) if data.size() > 0 else "",
+		"scope": scope_names[scope_id] if scope_id >= 0 and scope_id < scope_names.size() else str(scope_id),
+		"type": type_string(int(data[2])) if data.size() > 2 else "",
+		"value": data[3] if data.size() > 3 else null,
+		"raw": data
+	}
+
+func _append_captured_message(session_id: int, message: String, data: Array) -> void:
+	_captured_messages.append({
+		"session_id": session_id,
+		"message": message,
+		"data": data,
+		"timestamp": Time.get_unix_time_from_system()
+	})
+	if _captured_messages.size() > _max_messages:
+		_captured_messages = _captured_messages.slice(_captured_messages.size() - _max_messages)
+
+func _for_each_session(session_id: int, action: Callable, require_active: bool = false) -> Dictionary:
+	var sessions: Array = get_sessions()
+	if sessions.is_empty():
+		return {"status": "no_sessions", "sessions_updated": 0}
+	if session_id >= 0:
+		var session: EditorDebuggerSession = get_session(session_id)
+		if not session:
+			return {"error": "Debugger session not found: " + str(session_id)}
+		if require_active and not session.is_active():
+			return {"status": "no_active_sessions", "sessions_updated": 0}
+		action.call(session)
+		return {"status": "success", "sessions_updated": 1}
+	var updated: int = 0
+	for session in sessions:
+		if session and (not require_active or session.is_active()):
+			action.call(session)
+			updated += 1
+	if require_active and updated == 0:
+		return {"status": "no_active_sessions", "sessions_updated": 0}
+	return {"status": "success", "sessions_updated": updated}

--- a/addons/godot_mcp/native_mcp/mcp_debugger_bridge.gd
+++ b/addons/godot_mcp/native_mcp/mcp_debugger_bridge.gd
@@ -18,6 +18,7 @@ var _connected_script_debuggers: Array[Object] = []
 var _latest_stack_dump: Array = []
 var _latest_stack_variables: Dictionary = {}
 var _pending_stack_vars_frame: int = 0
+var _message_sequence: int = 0
 
 func _setup_session(session_id: int) -> void:
 	call_deferred("_refresh_script_debugger_connections")
@@ -107,6 +108,54 @@ func get_captured_messages(count: int = 100, offset: int = 0, order: String = "d
 func get_capture_prefixes() -> Array[String]:
 	return _capture_prefixes.duplicate()
 
+func get_latest_message_payload(message: String, match_fields: Dictionary = {}) -> Variant:
+	for index in range(_captured_messages.size() - 1, -1, -1):
+		var entry: Dictionary = _captured_messages[index]
+		if str(entry.get("message", "")) != message:
+			continue
+		var captured_data: Array = entry.get("data", [])
+		var payload: Variant = captured_data[0] if not captured_data.is_empty() else null
+		if _payload_matches(payload, match_fields):
+			return payload
+	return null
+
+func request_runtime_message(message: String, data: Array = [], response_messages: Array = [], error_messages: Array = ["mcp:error"], session_id: int = -1, timeout_ms: int = 1500) -> Dictionary:
+	var baseline_sequence: int = _message_sequence
+	var send_result: Dictionary = send_debugger_message("mcp:" + message, data, session_id)
+	if send_result.has("error"):
+		return send_result
+	if send_result.get("sessions_updated", 0) <= 0:
+		return send_result
+
+	var wait_until: int = Time.get_ticks_msec() + maxi(timeout_ms, 1)
+	while Time.get_ticks_msec() <= wait_until:
+		var captured: Dictionary = _find_captured_message_after_sequence(baseline_sequence, response_messages, error_messages)
+		if not captured.is_empty():
+			var payload: Variant = null
+			var captured_data: Array = captured.get("data", [])
+			if not captured_data.is_empty():
+				payload = captured_data[0]
+			if error_messages.has(captured.get("message", "")):
+				return {
+					"error": _extract_runtime_error(payload),
+					"message": captured.get("message", ""),
+					"payload": payload,
+					"captured": captured
+				}
+			return {
+				"status": "success",
+				"message": captured.get("message", ""),
+				"payload": payload,
+				"captured": captured
+			}
+		OS.delay_msec(10)
+
+	return {
+		"error": "Timed out waiting for runtime response: " + message,
+		"status": "timeout",
+		"response_messages": response_messages
+	}
+
 func _refresh_script_debugger_connections() -> void:
 	var tree: SceneTree = Engine.get_main_loop() as SceneTree
 	if not tree:
@@ -161,7 +210,9 @@ func _decode_stack_variable(data: Array) -> Dictionary:
 	}
 
 func _append_captured_message(session_id: int, message: String, data: Array) -> void:
+	_message_sequence += 1
 	_captured_messages.append({
+		"sequence": _message_sequence,
 		"session_id": session_id,
 		"message": message,
 		"data": data,
@@ -169,6 +220,30 @@ func _append_captured_message(session_id: int, message: String, data: Array) -> 
 	})
 	if _captured_messages.size() > _max_messages:
 		_captured_messages = _captured_messages.slice(_captured_messages.size() - _max_messages)
+
+func _find_captured_message_after_sequence(sequence: int, response_messages: Array, error_messages: Array) -> Dictionary:
+	for entry in _captured_messages:
+		if int(entry.get("sequence", 0)) <= sequence:
+			continue
+		var message: String = str(entry.get("message", ""))
+		if response_messages.has(message) or error_messages.has(message):
+			return entry
+	return {}
+
+func _extract_runtime_error(payload: Variant) -> String:
+	if payload is Dictionary:
+		return str(payload.get("message", payload))
+	return str(payload)
+
+func _payload_matches(payload: Variant, match_fields: Dictionary) -> bool:
+	if match_fields.is_empty():
+		return true
+	if not (payload is Dictionary):
+		return false
+	for key in match_fields:
+		if payload.get(key) != match_fields[key]:
+			return false
+	return true
 
 func _for_each_session(session_id: int, action: Callable, require_active: bool = false) -> Dictionary:
 	var sessions: Array = get_sessions()

--- a/addons/godot_mcp/native_mcp/mcp_debugger_bridge.gd.uid
+++ b/addons/godot_mcp/native_mcp/mcp_debugger_bridge.gd.uid
@@ -1,0 +1,1 @@
+uid://cfkyccbpb8xq1

--- a/addons/godot_mcp/runtime/mcp_runtime_probe.gd
+++ b/addons/godot_mcp/runtime/mcp_runtime_probe.gd
@@ -1,0 +1,103 @@
+class_name MCPRuntimeProbe
+extends Node
+
+const CAPTURE_PREFIX: StringName = &"mcp"
+
+func _ready() -> void:
+	if EngineDebugger.is_active() and not EngineDebugger.has_capture(CAPTURE_PREFIX):
+		EngineDebugger.register_message_capture(CAPTURE_PREFIX, Callable(self, "_capture_mcp_message"))
+		EngineDebugger.send_message("mcp:probe_ready", [_get_runtime_info()])
+
+func _exit_tree() -> void:
+	if EngineDebugger.is_active() and EngineDebugger.has_capture(CAPTURE_PREFIX):
+		EngineDebugger.unregister_message_capture(CAPTURE_PREFIX)
+
+func _capture_mcp_message(message: String, data: Array) -> bool:
+	match message:
+		"ping":
+			EngineDebugger.send_message("mcp:pong", [_get_runtime_info()])
+			return true
+		"get_runtime_info":
+			EngineDebugger.send_message("mcp:runtime_info", [_get_runtime_info()])
+			return true
+		"get_scene_tree":
+			var max_depth: int = 6
+			if not data.is_empty() and data[0] is int:
+				max_depth = data[0]
+			var root: Node = get_tree().current_scene
+			if not root:
+				root = get_tree().root
+			EngineDebugger.send_message("mcp:scene_tree", [_serialize_node(root, 0, max_depth)])
+			return true
+		"inspect_node":
+			if data.is_empty():
+				EngineDebugger.send_message("mcp:error", [{"message": "inspect_node requires a NodePath string"}])
+				return true
+			var node: Node = get_node_or_null(NodePath(str(data[0])))
+			if not node:
+				EngineDebugger.send_message("mcp:error", [{"message": "Node not found: " + str(data[0])}])
+				return true
+			EngineDebugger.send_message("mcp:node", [_serialize_node(node, 0, 1, true)])
+			return true
+		"debug_break":
+			EngineDebugger.debug(true, false)
+			return true
+		_:
+			return false
+
+func _get_runtime_info() -> Dictionary:
+	return {
+		"fps": Engine.get_frames_per_second(),
+		"physics_frames": Engine.get_physics_frames(),
+		"process_frames": Engine.get_process_frames(),
+		"debugger_active": EngineDebugger.is_active(),
+		"current_scene": str(get_tree().current_scene.get_path()) if get_tree().current_scene else "",
+		"node_count": _count_nodes(get_tree().root)
+	}
+
+func _serialize_node(node: Node, depth: int, max_depth: int, include_properties: bool = false) -> Dictionary:
+	var result: Dictionary = {
+		"name": node.name,
+		"type": node.get_class(),
+		"path": str(node.get_path()),
+		"child_count": node.get_child_count()
+	}
+	if include_properties:
+		result["properties"] = _serialize_properties(node)
+	if max_depth >= 0 and depth >= max_depth:
+		return result
+	var children: Array[Dictionary] = []
+	for child in node.get_children():
+		children.append(_serialize_node(child, depth + 1, max_depth))
+	result["children"] = children
+	return result
+
+func _serialize_properties(node: Node) -> Dictionary:
+	var properties: Dictionary = {}
+	for property in node.get_property_list():
+		var name: String = property.get("name", "")
+		var usage: int = property.get("usage", 0)
+		if name.begins_with("_") \
+				or (usage & PROPERTY_USAGE_CATEGORY) != 0 \
+				or (usage & PROPERTY_USAGE_GROUP) != 0 \
+				or (usage & PROPERTY_USAGE_SUBGROUP) != 0:
+			continue
+		var value: Variant = node.get(name)
+		match typeof(value):
+			TYPE_BOOL, TYPE_INT, TYPE_FLOAT, TYPE_STRING:
+				properties[name] = value
+			TYPE_VECTOR2:
+				properties[name] = {"x": value.x, "y": value.y}
+			TYPE_VECTOR3:
+				properties[name] = {"x": value.x, "y": value.y, "z": value.z}
+			TYPE_COLOR:
+				properties[name] = {"r": value.r, "g": value.g, "b": value.b, "a": value.a}
+			_:
+				properties[name] = str(value)
+	return properties
+
+func _count_nodes(node: Node) -> int:
+	var count: int = 1
+	for child in node.get_children():
+		count += _count_nodes(child)
+	return count

--- a/addons/godot_mcp/runtime/mcp_runtime_probe.gd
+++ b/addons/godot_mcp/runtime/mcp_runtime_probe.gd
@@ -33,12 +33,18 @@ func _capture_mcp_message(message: String, data: Array) -> bool:
 			if data.is_empty():
 				EngineDebugger.send_message("mcp:error", [{"message": "inspect_node requires a NodePath string"}])
 				return true
-			var node: Node = get_node_or_null(NodePath(str(data[0])))
+			var node: Node = _resolve_target_node(str(data[0]))
 			if not node:
 				EngineDebugger.send_message("mcp:error", [{"message": "Node not found: " + str(data[0])}])
 				return true
 			EngineDebugger.send_message("mcp:node", [_serialize_node(node, 0, 1, true)])
 			return true
+		"set_node_property":
+			return _handle_set_node_property(data)
+		"call_node_method":
+			return _handle_call_node_method(data)
+		"evaluate_expression":
+			return _handle_evaluate_expression(data)
 		"debug_break":
 			EngineDebugger.debug(true, false)
 			return true
@@ -93,8 +99,153 @@ func _serialize_properties(node: Node) -> Dictionary:
 			TYPE_COLOR:
 				properties[name] = {"r": value.r, "g": value.g, "b": value.b, "a": value.a}
 			_:
-				properties[name] = str(value)
+				properties[name] = _serialize_value(value)
 	return properties
+
+func _handle_set_node_property(data: Array) -> bool:
+	if data.size() < 3:
+		EngineDebugger.send_message("mcp:error", [{"message": "set_node_property requires node_path, property_name, property_value"}])
+		return true
+	var node: Node = _resolve_target_node(str(data[0]))
+	if not node:
+		EngineDebugger.send_message("mcp:error", [{"message": "Node not found: " + str(data[0])}])
+		return true
+	var property_name: String = str(data[1])
+	if not property_name in node:
+		EngineDebugger.send_message("mcp:error", [{"message": "Property not found on node: " + property_name}])
+		return true
+	var old_value: Variant = node.get(property_name)
+	var converted_value: Variant = _convert_value_for_property(node, property_name, data[2])
+	node.set(property_name, converted_value)
+	EngineDebugger.send_message("mcp:node_property_updated", [{
+		"node_path": str(node.get_path()),
+		"property_name": property_name,
+		"old_value": _serialize_value(old_value),
+		"new_value": _serialize_value(node.get(property_name))
+	}])
+	return true
+
+func _handle_call_node_method(data: Array) -> bool:
+	if data.size() < 2:
+		EngineDebugger.send_message("mcp:error", [{"message": "call_node_method requires node_path and method_name"}])
+		return true
+	var node: Node = _resolve_target_node(str(data[0]))
+	if not node:
+		EngineDebugger.send_message("mcp:error", [{"message": "Node not found: " + str(data[0])}])
+		return true
+	var method_name: String = str(data[1])
+	if not node.has_method(method_name):
+		EngineDebugger.send_message("mcp:error", [{"message": "Method not found on node: " + method_name}])
+		return true
+	var arguments: Array = []
+	if data.size() >= 3 and data[2] is Array:
+		arguments = data[2]
+	var result: Variant = node.callv(method_name, arguments)
+	EngineDebugger.send_message("mcp:node_method_result", [{
+		"node_path": str(node.get_path()),
+		"method_name": method_name,
+		"arguments": _serialize_value(arguments),
+		"result": _serialize_value(result)
+	}])
+	return true
+
+func _handle_evaluate_expression(data: Array) -> bool:
+	if data.is_empty():
+		EngineDebugger.send_message("mcp:error", [{"message": "evaluate_expression requires an expression string"}])
+		return true
+	var expression_text: String = str(data[0])
+	var node_path: String = ""
+	if data.size() >= 2:
+		node_path = str(data[1])
+	var base_instance: Object = _resolve_target_node(node_path)
+	if not base_instance:
+		base_instance = get_tree().current_scene if get_tree().current_scene else self
+	var expression: Expression = Expression.new()
+	var parse_error: int = expression.parse(expression_text, [])
+	if parse_error != OK:
+		EngineDebugger.send_message("mcp:error", [{
+			"message": "Expression parse failed",
+			"code": parse_error,
+			"expression": expression_text
+		}])
+		return true
+	var result: Variant = expression.execute([], base_instance, false)
+	if expression.has_execute_failed():
+		EngineDebugger.send_message("mcp:error", [{
+			"message": "Expression execution failed",
+			"expression": expression_text
+		}])
+		return true
+	EngineDebugger.send_message("mcp:expression_result", [{
+		"expression": expression_text,
+		"node_path": str(base_instance.get_path()) if base_instance is Node else "",
+		"value": _serialize_value(result)
+	}])
+	return true
+
+func _resolve_target_node(node_path: String) -> Node:
+	if node_path.is_empty() or node_path == ".":
+		return get_tree().current_scene if get_tree().current_scene else get_tree().root
+	if node_path == "/root":
+		return get_tree().root
+	return get_node_or_null(NodePath(node_path))
+
+func _convert_value_for_property(node: Node, property_name: String, value: Variant) -> Variant:
+	if value is String:
+		var parsed: Variant = JSON.parse_string(value)
+		if parsed != null:
+			value = parsed
+
+	var property_type: int = TYPE_NIL
+	for property_info in node.get_property_list():
+		if property_info.get("name", "") == property_name:
+			property_type = int(property_info.get("type", TYPE_NIL))
+			break
+
+	match property_type:
+		TYPE_VECTOR2:
+			if value is Dictionary:
+				return Vector2(float(value.get("x", 0.0)), float(value.get("y", 0.0)))
+		TYPE_VECTOR3:
+			if value is Dictionary:
+				return Vector3(float(value.get("x", 0.0)), float(value.get("y", 0.0)), float(value.get("z", 0.0)))
+		TYPE_COLOR:
+			if value is Dictionary:
+				return Color(float(value.get("r", 0.0)), float(value.get("g", 0.0)), float(value.get("b", 0.0)), float(value.get("a", 1.0)))
+		TYPE_BOOL:
+			if value is String:
+				return value.to_lower() == "true"
+		TYPE_INT:
+			if value is String:
+				return int(value)
+		TYPE_FLOAT:
+			if value is String:
+				return float(value)
+
+	return value
+
+func _serialize_value(value: Variant) -> Variant:
+	match typeof(value):
+		TYPE_NIL, TYPE_BOOL, TYPE_INT, TYPE_FLOAT, TYPE_STRING:
+			return value
+		TYPE_VECTOR2:
+			return {"x": value.x, "y": value.y}
+		TYPE_VECTOR3:
+			return {"x": value.x, "y": value.y, "z": value.z}
+		TYPE_COLOR:
+			return {"r": value.r, "g": value.g, "b": value.b, "a": value.a}
+		TYPE_ARRAY:
+			var result: Array = []
+			for item in value:
+				result.append(_serialize_value(item))
+			return result
+		TYPE_DICTIONARY:
+			var result: Dictionary = {}
+			for key in value:
+				result[str(key)] = _serialize_value(value[key])
+			return result
+		_:
+			return str(value)
 
 func _count_nodes(node: Node) -> int:
 	var count: int = 1

--- a/addons/godot_mcp/runtime/mcp_runtime_probe.gd.uid
+++ b/addons/godot_mcp/runtime/mcp_runtime_probe.gd.uid
@@ -1,0 +1,1 @@
+uid://bsg12huaf1u5i

--- a/addons/godot_mcp/tools/debug_tools_native.gd
+++ b/addons/godot_mcp/tools/debug_tools_native.gd
@@ -23,6 +23,19 @@ func _get_editor_interface() -> EditorInterface:
 			return plugin.get_editor_interface()
 	return null
 
+func _get_user_scene_root() -> Node:
+	var editor_interface: EditorInterface = _get_editor_interface()
+	if not editor_interface:
+		return null
+	var scene_root: Node = editor_interface.get_edited_scene_root()
+	if scene_root and not scene_root.name.begins_with("@") and scene_root.get_class() != "PanelContainer":
+		return scene_root
+	var open_scenes: Array = editor_interface.get_open_scenes()
+	for scene in open_scenes:
+		if scene and not scene.name.begins_with("@") and scene.get_class() != "PanelContainer":
+			return scene
+	return scene_root
+
 # ============================================================================
 # 工具注册
 # ============================================================================
@@ -50,6 +63,14 @@ func register_tools(server_core: RefCounted) -> void:
 	_register_remove_runtime_probe(server_core)
 	_register_request_debug_break(server_core)
 	_register_send_debug_command(server_core)
+	_register_get_runtime_info(server_core)
+	_register_get_runtime_scene_tree(server_core)
+	_register_inspect_runtime_node(server_core)
+	_register_update_runtime_node_property(server_core)
+	_register_call_runtime_node_method(server_core)
+	_register_evaluate_runtime_expression(server_core)
+	_register_await_runtime_condition(server_core)
+	_register_assert_runtime_condition(server_core)
 
 func _on_log_message(level: String, message: String) -> void:
 	var log_entry: String = "[%s] %s" % [level, message]
@@ -378,7 +399,7 @@ func _tool_install_runtime_probe(params: Dictionary) -> Dictionary:
 	var editor_interface: EditorInterface = _get_editor_interface()
 	if not editor_interface:
 		return {"error": "Editor interface not available"}
-	var scene_root: Node = editor_interface.get_edited_scene_root()
+	var scene_root: Node = _get_user_scene_root()
 	if not scene_root:
 		return {"error": "No scene is currently open"}
 	var node_name: String = params.get("node_name", "MCPRuntimeProbe")
@@ -419,7 +440,7 @@ func _tool_remove_runtime_probe(params: Dictionary) -> Dictionary:
 	var editor_interface: EditorInterface = _get_editor_interface()
 	if not editor_interface:
 		return {"error": "Editor interface not available"}
-	var scene_root: Node = editor_interface.get_edited_scene_root()
+	var scene_root: Node = _get_user_scene_root()
 	if not scene_root:
 		return {"error": "No scene is currently open"}
 	var node_name: String = params.get("node_name", "MCPRuntimeProbe")
@@ -483,6 +504,275 @@ func _tool_send_debug_command(params: Dictionary) -> Dictionary:
 	if command.begins_with("get_stack"):
 		result["note"] = "Godot may route stack responses to the built-in ScriptEditorDebugger UI instead of EditorDebuggerPlugin captures."
 	return result
+
+func _register_get_runtime_info(server_core: RefCounted) -> void:
+	server_core.register_tool(
+		"get_runtime_info",
+		"Query the running game instance through the MCP runtime probe and return runtime metrics.",
+		{"type": "object", "properties": {"session_id": {"type": "integer"}, "timeout_ms": {"type": "integer", "default": 1500}}},
+		Callable(self, "_tool_get_runtime_info"),
+		{"type": "object", "properties": {"fps": {"type": "number"}, "physics_frames": {"type": "integer"}, "process_frames": {"type": "integer"}, "debugger_active": {"type": "boolean"}, "current_scene": {"type": "string"}, "node_count": {"type": "integer"}}},
+		{"readOnlyHint": true, "destructiveHint": false, "idempotentHint": true, "openWorldHint": true}
+	)
+
+func _tool_get_runtime_info(params: Dictionary) -> Dictionary:
+	var result: Dictionary = _request_runtime_probe("get_runtime_info", [], ["mcp:runtime_info"], params)
+	if result.get("status", "") == "pending":
+		var bridge: RefCounted = _get_debugger_bridge()
+		if bridge:
+			var probe_ready: Variant = bridge.get_latest_message_payload("mcp:probe_ready")
+			if probe_ready is Dictionary:
+				var fallback: Dictionary = probe_ready.duplicate(true)
+				fallback["status"] = "stale"
+				fallback["refresh_result"] = result.get("refresh_result", {})
+				return fallback
+	return result
+
+func _register_get_runtime_scene_tree(server_core: RefCounted) -> void:
+	server_core.register_tool(
+		"get_runtime_scene_tree",
+		"Read the live runtime scene tree from the running game instance.",
+		{"type": "object", "properties": {"max_depth": {"type": "integer", "default": 6}, "session_id": {"type": "integer"}, "timeout_ms": {"type": "integer", "default": 1500}}},
+		Callable(self, "_tool_get_runtime_scene_tree"),
+		{"type": "object", "properties": {"name": {"type": "string"}, "type": {"type": "string"}, "path": {"type": "string"}, "child_count": {"type": "integer"}, "children": {"type": "array"}}},
+		{"readOnlyHint": true, "destructiveHint": false, "idempotentHint": true, "openWorldHint": true}
+	)
+
+func _tool_get_runtime_scene_tree(params: Dictionary) -> Dictionary:
+	return _request_runtime_probe("get_scene_tree", [params.get("max_depth", 6)], ["mcp:scene_tree"], params)
+
+func _register_inspect_runtime_node(server_core: RefCounted) -> void:
+	server_core.register_tool(
+		"inspect_runtime_node",
+		"Inspect a live runtime node and its serializable properties through the runtime probe.",
+		{
+			"type": "object",
+			"properties": {
+				"node_path": {"type": "string"},
+				"session_id": {"type": "integer"},
+				"timeout_ms": {"type": "integer", "default": 1500}
+			},
+			"required": ["node_path"]
+		},
+		Callable(self, "_tool_inspect_runtime_node"),
+		{"type": "object", "properties": {"name": {"type": "string"}, "type": {"type": "string"}, "path": {"type": "string"}, "properties": {"type": "object"}}},
+		{"readOnlyHint": true, "destructiveHint": false, "idempotentHint": true, "openWorldHint": true}
+	)
+
+func _tool_inspect_runtime_node(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	if node_path.is_empty():
+		return {"error": "Missing required parameter: node_path"}
+	return _request_runtime_probe("inspect_node", [node_path], ["mcp:node"], params, {"path": node_path})
+
+func _register_update_runtime_node_property(server_core: RefCounted) -> void:
+	server_core.register_tool(
+		"update_runtime_node_property",
+		"Modify a property on a live runtime node through the runtime probe.",
+		{
+			"type": "object",
+			"properties": {
+				"node_path": {"type": "string"},
+				"property_name": {"type": "string"},
+				"property_value": {},
+				"session_id": {"type": "integer"},
+				"timeout_ms": {"type": "integer", "default": 1500}
+			},
+			"required": ["node_path", "property_name", "property_value"]
+		},
+		Callable(self, "_tool_update_runtime_node_property"),
+		{"type": "object", "properties": {"node_path": {"type": "string"}, "property_name": {"type": "string"}, "old_value": {}, "new_value": {}}},
+		{"readOnlyHint": false, "destructiveHint": false, "idempotentHint": false, "openWorldHint": true}
+	)
+
+func _tool_update_runtime_node_property(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	var property_name: String = params.get("property_name", "")
+	if node_path.is_empty() or property_name.is_empty() or not params.has("property_value"):
+		return {"error": "node_path, property_name, and property_value are required"}
+	return _request_runtime_probe("set_node_property", [node_path, property_name, params.get("property_value")], ["mcp:node_property_updated"], params, {"node_path": node_path, "property_name": property_name})
+
+func _register_call_runtime_node_method(server_core: RefCounted) -> void:
+	server_core.register_tool(
+		"call_runtime_node_method",
+		"Call a method on a live runtime node and return the serialized result.",
+		{
+			"type": "object",
+			"properties": {
+				"node_path": {"type": "string"},
+				"method_name": {"type": "string"},
+				"arguments": {"type": "array"},
+				"session_id": {"type": "integer"},
+				"timeout_ms": {"type": "integer", "default": 1500}
+			},
+			"required": ["node_path", "method_name"]
+		},
+		Callable(self, "_tool_call_runtime_node_method"),
+		{"type": "object", "properties": {"node_path": {"type": "string"}, "method_name": {"type": "string"}, "arguments": {"type": "array"}, "result": {}}},
+		{"readOnlyHint": false, "destructiveHint": false, "idempotentHint": false, "openWorldHint": true}
+	)
+
+func _tool_call_runtime_node_method(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	var method_name: String = params.get("method_name", "")
+	if node_path.is_empty() or method_name.is_empty():
+		return {"error": "node_path and method_name are required"}
+	return _request_runtime_probe("call_node_method", [node_path, method_name, params.get("arguments", [])], ["mcp:node_method_result"], params, {"node_path": node_path, "method_name": method_name})
+
+func _register_evaluate_runtime_expression(server_core: RefCounted) -> void:
+	server_core.register_tool(
+		"evaluate_runtime_expression",
+		"Evaluate a GDScript Expression in the running game, optionally relative to a target node.",
+		{
+			"type": "object",
+			"properties": {
+				"expression": {"type": "string"},
+				"node_path": {"type": "string"},
+				"session_id": {"type": "integer"},
+				"timeout_ms": {"type": "integer", "default": 1500}
+			},
+			"required": ["expression"]
+		},
+		Callable(self, "_tool_evaluate_runtime_expression"),
+		{"type": "object", "properties": {"expression": {"type": "string"}, "node_path": {"type": "string"}, "value": {}}},
+		{"readOnlyHint": false, "destructiveHint": false, "idempotentHint": false, "openWorldHint": true}
+	)
+
+func _tool_evaluate_runtime_expression(params: Dictionary) -> Dictionary:
+	var expression: String = params.get("expression", "")
+	if expression.is_empty():
+		return {"error": "Missing required parameter: expression"}
+	var payload: Array = [expression, params.get("node_path", "")]
+	return _request_runtime_probe("evaluate_expression", payload, ["mcp:expression_result"], params, {"expression": expression})
+
+func _register_await_runtime_condition(server_core: RefCounted) -> void:
+	server_core.register_tool(
+		"await_runtime_condition",
+		"Poll a runtime expression until it becomes truthy or the timeout expires.",
+		{
+			"type": "object",
+			"properties": {
+				"expression": {"type": "string"},
+				"node_path": {"type": "string"},
+				"timeout_ms": {"type": "integer", "default": 3000},
+				"poll_interval_ms": {"type": "integer", "default": 100},
+				"session_id": {"type": "integer"}
+			},
+			"required": ["expression"]
+		},
+		Callable(self, "_tool_await_runtime_condition"),
+		{"type": "object", "properties": {"condition_met": {"type": "boolean"}, "attempts": {"type": "integer"}, "elapsed_ms": {"type": "integer"}, "last_value": {}}},
+		{"readOnlyHint": false, "destructiveHint": false, "idempotentHint": false, "openWorldHint": true}
+	)
+
+func _tool_await_runtime_condition(params: Dictionary) -> Dictionary:
+	var expression: String = params.get("expression", "")
+	if expression.is_empty():
+		return {"error": "Missing required parameter: expression"}
+	var result: Dictionary = _tool_evaluate_runtime_expression(params)
+	if result.has("error"):
+		return result
+	if result.get("status", "") == "pending":
+		return {
+			"status": "pending",
+			"condition_met": false,
+			"last_value": null,
+			"refresh_result": result.get("refresh_result", {})
+		}
+	var last_value: Variant = result.get("value", null)
+	var condition_met: bool = _is_truthy_runtime_value(last_value)
+	return {
+		"status": "success" if condition_met else "failed",
+		"condition_met": condition_met,
+		"last_value": last_value,
+		"refresh_result": result.get("refresh_result", {})
+	}
+
+func _register_assert_runtime_condition(server_core: RefCounted) -> void:
+	server_core.register_tool(
+		"assert_runtime_condition",
+		"Assert that a runtime expression becomes truthy within the timeout window.",
+		{
+			"type": "object",
+			"properties": {
+				"expression": {"type": "string"},
+				"node_path": {"type": "string"},
+				"timeout_ms": {"type": "integer", "default": 3000},
+				"poll_interval_ms": {"type": "integer", "default": 100},
+				"session_id": {"type": "integer"},
+				"description": {"type": "string"}
+			},
+			"required": ["expression"]
+		},
+		Callable(self, "_tool_assert_runtime_condition"),
+		{"type": "object", "properties": {"status": {"type": "string"}, "description": {"type": "string"}, "attempts": {"type": "integer"}, "elapsed_ms": {"type": "integer"}, "last_value": {}}},
+		{"readOnlyHint": false, "destructiveHint": false, "idempotentHint": false, "openWorldHint": true}
+	)
+
+func _tool_assert_runtime_condition(params: Dictionary) -> Dictionary:
+	var wait_result: Dictionary = _tool_await_runtime_condition(params)
+	if wait_result.has("error"):
+		return wait_result
+	if wait_result.get("status", "") == "pending":
+		return {
+			"status": "pending",
+			"description": params.get("description", params.get("expression", "")),
+			"last_value": null,
+			"refresh_result": wait_result.get("refresh_result", {})
+		}
+	if not wait_result.get("condition_met", false):
+		return {
+			"error": "Runtime condition was not met within timeout",
+			"description": params.get("description", params.get("expression", "")),
+			"last_value": wait_result.get("last_value", null)
+		}
+	return {
+		"status": "success",
+		"description": params.get("description", params.get("expression", "")),
+		"last_value": wait_result.get("last_value", null),
+		"refresh_result": wait_result.get("refresh_result", {})
+	}
+
+func _request_runtime_probe(command: String, payload: Array, response_messages: Array, params: Dictionary, match_fields: Dictionary = {}) -> Dictionary:
+	var bridge: RefCounted = _get_debugger_bridge()
+	if not bridge:
+		return {"error": "Debugger bridge is not available"}
+	var refresh_result: Dictionary = bridge.send_debugger_message(
+		"mcp:" + command,
+		payload,
+		int(params.get("session_id", -1))
+	)
+	if refresh_result.has("error"):
+		return refresh_result
+	if refresh_result.get("status", "") == "no_active_sessions":
+		return {"status": "no_active_sessions", "refresh_result": refresh_result}
+	for message_name in response_messages:
+		var runtime_payload: Variant = bridge.get_latest_message_payload(message_name, match_fields)
+		if runtime_payload is Dictionary:
+			var response: Dictionary = runtime_payload.duplicate(true)
+			response["status"] = "success"
+			response["refresh_result"] = refresh_result
+			return response
+		if runtime_payload != null:
+			return {"status": "success", "value": runtime_payload, "refresh_result": refresh_result}
+	return {"status": "pending", "refresh_result": refresh_result, "response_messages": response_messages}
+
+func _is_truthy_runtime_value(value: Variant) -> bool:
+	match typeof(value):
+		TYPE_NIL:
+			return false
+		TYPE_BOOL:
+			return value
+		TYPE_INT, TYPE_FLOAT:
+			return value != 0
+		TYPE_STRING:
+			return not String(value).is_empty()
+		TYPE_ARRAY:
+			return not value.is_empty()
+		TYPE_DICTIONARY:
+			return not value.is_empty()
+		_:
+			return true
 
 func _get_mcp_logs(types: Array, count: int, offset: int, order: String) -> Dictionary:
 	_log_mutex.lock()

--- a/addons/godot_mcp/tools/debug_tools_native.gd
+++ b/addons/godot_mcp/tools/debug_tools_native.gd
@@ -38,6 +38,18 @@ func register_tools(server_core: RefCounted) -> void:
 	_register_debug_print(server_core)
 	_register_execute_editor_script(server_core)
 	_register_clear_output(server_core)
+	_register_get_debugger_sessions(server_core)
+	_register_set_debugger_breakpoint(server_core)
+	_register_send_debugger_message(server_core)
+	_register_toggle_debugger_profiler(server_core)
+	_register_get_debugger_messages(server_core)
+	_register_add_debugger_capture_prefix(server_core)
+	_register_get_debug_stack_frames(server_core)
+	_register_get_debug_stack_variables(server_core)
+	_register_install_runtime_probe(server_core)
+	_register_remove_runtime_probe(server_core)
+	_register_request_debug_break(server_core)
+	_register_send_debug_command(server_core)
 
 func _on_log_message(level: String, message: String) -> void:
 	var log_entry: String = "[%s] %s" % [level, message]
@@ -123,6 +135,354 @@ func _tool_get_editor_logs(params: Dictionary) -> Dictionary:
 		return _get_runtime_logs(types, count, offset, order)
 
 	return _get_mcp_logs(types, count, offset, order)
+
+func _get_debugger_bridge() -> RefCounted:
+	if Engine.has_meta("GodotMCPPlugin"):
+		var plugin = Engine.get_meta("GodotMCPPlugin")
+		if plugin and plugin.has_method("get_debugger_bridge"):
+			return plugin.get_debugger_bridge()
+	return null
+
+func _register_get_debugger_sessions(server_core: RefCounted) -> void:
+	server_core.register_tool(
+		"get_debugger_sessions",
+		"List Godot editor debugger sessions and their active/break state.",
+		{"type": "object", "properties": {}},
+		Callable(self, "_tool_get_debugger_sessions"),
+		{"type": "object", "properties": {"sessions": {"type": "array"}, "count": {"type": "integer"}}},
+		{"readOnlyHint": true, "destructiveHint": false, "idempotentHint": true, "openWorldHint": false}
+	)
+
+func _tool_get_debugger_sessions(params: Dictionary) -> Dictionary:
+	var bridge: RefCounted = _get_debugger_bridge()
+	if not bridge:
+		return {"error": "Debugger bridge is not available"}
+	var sessions: Array = bridge.get_sessions_info()
+	return {"sessions": sessions, "count": sessions.size()}
+
+func _register_set_debugger_breakpoint(server_core: RefCounted) -> void:
+	server_core.register_tool(
+		"set_debugger_breakpoint",
+		"Enable or disable a breakpoint in active Godot debugger sessions.",
+		{
+			"type": "object",
+			"properties": {
+				"path": {"type": "string", "description": "Script path, e.g. res://player.gd"},
+				"line": {"type": "integer", "description": "1-based line number"},
+				"enabled": {"type": "boolean", "description": "Whether the breakpoint is enabled"},
+				"session_id": {"type": "integer", "description": "Optional debugger session id. Omit or use -1 for all sessions."}
+			},
+			"required": ["path", "line", "enabled"]
+		},
+		Callable(self, "_tool_set_debugger_breakpoint"),
+		{"type": "object", "properties": {"status": {"type": "string"}, "sessions_updated": {"type": "integer"}}},
+		{"readOnlyHint": false, "destructiveHint": false, "idempotentHint": true, "openWorldHint": false}
+	)
+
+func _tool_set_debugger_breakpoint(params: Dictionary) -> Dictionary:
+	var path: String = params.get("path", "")
+	var line: int = params.get("line", 0)
+	var enabled: bool = params.get("enabled", true)
+	var session_id: int = params.get("session_id", -1)
+	if path.is_empty():
+		return {"error": "Missing required parameter: path"}
+	if line < 1:
+		return {"error": "line must be >= 1"}
+	var bridge: RefCounted = _get_debugger_bridge()
+	if not bridge:
+		return {"error": "Debugger bridge is not available"}
+	return bridge.set_breakpoint(path, line, enabled, session_id)
+
+func _register_send_debugger_message(server_core: RefCounted) -> void:
+	server_core.register_tool(
+		"send_debugger_message",
+		"Send a custom debugger message to active Godot debugger sessions.",
+		{
+			"type": "object",
+			"properties": {
+				"message": {"type": "string"},
+				"data": {"type": "array"},
+				"session_id": {"type": "integer"}
+			},
+			"required": ["message"]
+		},
+		Callable(self, "_tool_send_debugger_message"),
+		{"type": "object", "properties": {"status": {"type": "string"}, "sessions_updated": {"type": "integer"}}},
+		{"readOnlyHint": false, "destructiveHint": false, "idempotentHint": false, "openWorldHint": true}
+	)
+
+func _tool_send_debugger_message(params: Dictionary) -> Dictionary:
+	var message: String = params.get("message", "")
+	var data: Array = params.get("data", [])
+	var session_id: int = params.get("session_id", -1)
+	if message.is_empty():
+		return {"error": "Missing required parameter: message"}
+	var bridge: RefCounted = _get_debugger_bridge()
+	if not bridge:
+		return {"error": "Debugger bridge is not available"}
+	return bridge.send_debugger_message(message, data, session_id)
+
+func _register_toggle_debugger_profiler(server_core: RefCounted) -> void:
+	server_core.register_tool(
+		"toggle_debugger_profiler",
+		"Toggle an EngineProfiler in active Godot debugger sessions.",
+		{
+			"type": "object",
+			"properties": {
+				"profiler": {"type": "string", "description": "Profiler name"},
+				"enabled": {"type": "boolean"},
+				"data": {"type": "array"},
+				"session_id": {"type": "integer"}
+			},
+			"required": ["profiler", "enabled"]
+		},
+		Callable(self, "_tool_toggle_debugger_profiler"),
+		{"type": "object", "properties": {"status": {"type": "string"}, "sessions_updated": {"type": "integer"}}},
+		{"readOnlyHint": false, "destructiveHint": false, "idempotentHint": true, "openWorldHint": true}
+	)
+
+func _tool_toggle_debugger_profiler(params: Dictionary) -> Dictionary:
+	var profiler: String = params.get("profiler", "")
+	var enabled: bool = params.get("enabled", false)
+	var data: Array = params.get("data", [])
+	var session_id: int = params.get("session_id", -1)
+	if profiler.is_empty():
+		return {"error": "Missing required parameter: profiler"}
+	var bridge: RefCounted = _get_debugger_bridge()
+	if not bridge:
+		return {"error": "Debugger bridge is not available"}
+	return bridge.toggle_profiler(profiler, enabled, data, session_id)
+
+func _register_get_debugger_messages(server_core: RefCounted) -> void:
+	server_core.register_tool(
+		"get_debugger_messages",
+		"Read custom messages captured by the Godot debugger bridge.",
+		{
+			"type": "object",
+			"properties": {
+				"count": {"type": "integer", "default": 100},
+				"offset": {"type": "integer", "default": 0},
+				"order": {"type": "string", "enum": ["asc", "desc"], "default": "desc"}
+			}
+		},
+		Callable(self, "_tool_get_debugger_messages"),
+		{"type": "object", "properties": {"messages": {"type": "array"}, "count": {"type": "integer"}, "total_available": {"type": "integer"}}},
+		{"readOnlyHint": true, "destructiveHint": false, "idempotentHint": true, "openWorldHint": false}
+	)
+
+func _tool_get_debugger_messages(params: Dictionary) -> Dictionary:
+	var bridge: RefCounted = _get_debugger_bridge()
+	if not bridge:
+		return {"error": "Debugger bridge is not available"}
+	return bridge.get_captured_messages(params.get("count", 100), params.get("offset", 0), params.get("order", "desc"))
+
+func _register_add_debugger_capture_prefix(server_core: RefCounted) -> void:
+	server_core.register_tool(
+		"add_debugger_capture_prefix",
+		"Allow the debugger bridge to capture custom EngineDebugger messages with the given prefix.",
+		{
+			"type": "object",
+			"properties": {
+				"prefix": {"type": "string", "description": "Message prefix without the trailing colon, or * for all prefixes."}
+			},
+			"required": ["prefix"]
+		},
+		Callable(self, "_tool_add_debugger_capture_prefix"),
+		{"type": "object", "properties": {"status": {"type": "string"}, "prefixes": {"type": "array"}}},
+		{"readOnlyHint": false, "destructiveHint": false, "idempotentHint": true, "openWorldHint": false}
+	)
+
+func _tool_add_debugger_capture_prefix(params: Dictionary) -> Dictionary:
+	var prefix: String = params.get("prefix", "")
+	if prefix.is_empty():
+		return {"error": "Missing required parameter: prefix"}
+	var bridge: RefCounted = _get_debugger_bridge()
+	if not bridge:
+		return {"error": "Debugger bridge is not available"}
+	bridge.add_capture_prefix(prefix)
+	return {"status": "success", "prefixes": bridge.get_capture_prefixes()}
+
+func _register_get_debug_stack_frames(server_core: RefCounted) -> void:
+	server_core.register_tool(
+		"get_debug_stack_frames",
+		"Return the latest captured script stack frames and request a fresh stack dump from breaked sessions.",
+		{
+			"type": "object",
+			"properties": {
+				"refresh": {"type": "boolean", "default": true},
+				"session_id": {"type": "integer", "description": "Optional debugger session id. Omit or use -1 for all active sessions."}
+			}
+		},
+		Callable(self, "_tool_get_debug_stack_frames"),
+		{"type": "object", "properties": {"frames": {"type": "array"}, "count": {"type": "integer"}, "refresh_result": {"type": "object"}}},
+		{"readOnlyHint": false, "destructiveHint": false, "idempotentHint": true, "openWorldHint": false}
+	)
+
+func _tool_get_debug_stack_frames(params: Dictionary) -> Dictionary:
+	var bridge: RefCounted = _get_debugger_bridge()
+	if not bridge:
+		return {"error": "Debugger bridge is not available"}
+	var refresh_result: Dictionary = {}
+	if params.get("refresh", true):
+		refresh_result = bridge.request_stack_dump(params.get("session_id", -1))
+	var frames: Array = bridge.get_latest_stack_dump()
+	return {"frames": frames, "count": frames.size(), "refresh_result": refresh_result}
+
+func _register_get_debug_stack_variables(server_core: RefCounted) -> void:
+	server_core.register_tool(
+		"get_debug_stack_variables",
+		"Return latest captured local/member/global variables for a stack frame and request a fresh variable dump.",
+		{
+			"type": "object",
+			"properties": {
+				"frame": {"type": "integer", "default": 0},
+				"refresh": {"type": "boolean", "default": true},
+				"session_id": {"type": "integer", "description": "Optional debugger session id. Omit or use -1 for all active sessions."}
+			}
+		},
+		Callable(self, "_tool_get_debug_stack_variables"),
+		{"type": "object", "properties": {"frame": {"type": "integer"}, "variables": {"type": "array"}, "count": {"type": "integer"}, "refresh_result": {"type": "object"}}},
+		{"readOnlyHint": false, "destructiveHint": false, "idempotentHint": true, "openWorldHint": false}
+	)
+
+func _tool_get_debug_stack_variables(params: Dictionary) -> Dictionary:
+	var bridge: RefCounted = _get_debugger_bridge()
+	if not bridge:
+		return {"error": "Debugger bridge is not available"}
+	var frame: int = params.get("frame", 0)
+	if frame < 0:
+		return {"error": "frame must be >= 0"}
+	var refresh_result: Dictionary = {}
+	if params.get("refresh", true):
+		refresh_result = bridge.request_stack_frame_vars(frame, params.get("session_id", -1))
+	var variables: Array = bridge.get_latest_stack_variables(frame)
+	return {"frame": frame, "variables": variables, "count": variables.size(), "refresh_result": refresh_result}
+
+func _register_install_runtime_probe(server_core: RefCounted) -> void:
+	server_core.register_tool(
+		"install_runtime_probe",
+		"Add the MCP runtime probe node to the current scene so the running game can answer debugger messages.",
+		{
+			"type": "object",
+			"properties": {
+				"node_name": {"type": "string", "default": "MCPRuntimeProbe"},
+				"persistent": {"type": "boolean", "default": true, "description": "Set owner so the probe is saved with the scene."}
+			}
+		},
+		Callable(self, "_tool_install_runtime_probe"),
+		{"type": "object", "properties": {"status": {"type": "string"}, "node_path": {"type": "string"}, "persistent": {"type": "boolean"}}},
+		{"readOnlyHint": false, "destructiveHint": false, "idempotentHint": true, "openWorldHint": false}
+	)
+
+func _tool_install_runtime_probe(params: Dictionary) -> Dictionary:
+	var editor_interface: EditorInterface = _get_editor_interface()
+	if not editor_interface:
+		return {"error": "Editor interface not available"}
+	var scene_root: Node = editor_interface.get_edited_scene_root()
+	if not scene_root:
+		return {"error": "No scene is currently open"}
+	var node_name: String = params.get("node_name", "MCPRuntimeProbe")
+	if node_name.is_empty():
+		return {"error": "node_name cannot be empty"}
+	var existing: Node = scene_root.get_node_or_null(NodePath(node_name))
+	if existing:
+		return {"status": "already_installed", "node_path": str(existing.get_path()), "persistent": existing.owner != null}
+	var script: Script = load("res://addons/godot_mcp/runtime/mcp_runtime_probe.gd")
+	if not script:
+		return {"error": "Failed to load runtime probe script"}
+	var probe: Node = Node.new()
+	probe.name = node_name
+	probe.set_script(script)
+	scene_root.add_child(probe)
+	var persistent: bool = params.get("persistent", true)
+	if persistent:
+		probe.owner = scene_root
+	editor_interface.mark_scene_as_unsaved()
+	return {"status": "success", "node_path": str(probe.get_path()), "persistent": persistent}
+
+func _register_remove_runtime_probe(server_core: RefCounted) -> void:
+	server_core.register_tool(
+		"remove_runtime_probe",
+		"Remove the MCP runtime probe node from the current scene.",
+		{
+			"type": "object",
+			"properties": {
+				"node_name": {"type": "string", "default": "MCPRuntimeProbe"}
+			}
+		},
+		Callable(self, "_tool_remove_runtime_probe"),
+		{"type": "object", "properties": {"status": {"type": "string"}, "removed_node": {"type": "string"}}},
+		{"readOnlyHint": false, "destructiveHint": true, "idempotentHint": true, "openWorldHint": false}
+	)
+
+func _tool_remove_runtime_probe(params: Dictionary) -> Dictionary:
+	var editor_interface: EditorInterface = _get_editor_interface()
+	if not editor_interface:
+		return {"error": "Editor interface not available"}
+	var scene_root: Node = editor_interface.get_edited_scene_root()
+	if not scene_root:
+		return {"error": "No scene is currently open"}
+	var node_name: String = params.get("node_name", "MCPRuntimeProbe")
+	var existing: Node = scene_root.get_node_or_null(NodePath(node_name))
+	if not existing:
+		return {"status": "not_installed", "removed_node": ""}
+	var removed_path: String = str(existing.get_path())
+	scene_root.remove_child(existing)
+	existing.queue_free()
+	editor_interface.mark_scene_as_unsaved()
+	return {"status": "success", "removed_node": removed_path}
+
+func _register_request_debug_break(server_core: RefCounted) -> void:
+	server_core.register_tool(
+		"request_debug_break",
+		"Ask the MCP runtime probe to enter Godot's script debugger break loop.",
+		{
+			"type": "object",
+			"properties": {
+				"session_id": {"type": "integer", "description": "Optional debugger session id. Omit or use -1 for all active sessions."}
+			}
+		},
+		Callable(self, "_tool_request_debug_break"),
+		{"type": "object", "properties": {"status": {"type": "string"}, "sessions_updated": {"type": "integer"}}},
+		{"readOnlyHint": false, "destructiveHint": false, "idempotentHint": false, "openWorldHint": true}
+	)
+
+func _tool_request_debug_break(params: Dictionary) -> Dictionary:
+	var bridge: RefCounted = _get_debugger_bridge()
+	if not bridge:
+		return {"error": "Debugger bridge is not available"}
+	return bridge.send_debugger_message("mcp:debug_break", [], params.get("session_id", -1))
+
+func _register_send_debug_command(server_core: RefCounted) -> void:
+	server_core.register_tool(
+		"send_debug_command",
+		"Send a raw Godot script-debugger command to active breaked sessions. Commands are handled by Godot's debug loop.",
+		{
+			"type": "object",
+			"properties": {
+				"command": {"type": "string", "enum": ["step", "next", "out", "continue", "get_stack_dump", "get_stack_frame_vars"]},
+				"data": {"type": "array", "description": "Command payload, e.g. [0] for get_stack_frame_vars frame 0."},
+				"session_id": {"type": "integer", "description": "Optional debugger session id. Omit or use -1 for all active sessions."}
+			},
+			"required": ["command"]
+		},
+		Callable(self, "_tool_send_debug_command"),
+		{"type": "object", "properties": {"status": {"type": "string"}, "sessions_updated": {"type": "integer"}, "note": {"type": "string"}}},
+		{"readOnlyHint": false, "destructiveHint": false, "idempotentHint": false, "openWorldHint": true}
+	)
+
+func _tool_send_debug_command(params: Dictionary) -> Dictionary:
+	var command: String = params.get("command", "")
+	var allowed: Array[String] = ["step", "next", "out", "continue", "get_stack_dump", "get_stack_frame_vars"]
+	if not allowed.has(command):
+		return {"error": "Unsupported debug command: " + command}
+	var bridge: RefCounted = _get_debugger_bridge()
+	if not bridge:
+		return {"error": "Debugger bridge is not available"}
+	var result: Dictionary = bridge.send_debugger_message(command, params.get("data", []), params.get("session_id", -1))
+	if command.begins_with("get_stack"):
+		result["note"] = "Godot may route stack responses to the built-in ScriptEditorDebugger UI instead of EditorDebuggerPlugin captures."
+	return result
 
 func _get_mcp_logs(types: Array, count: int, offset: int, order: String) -> Dictionary:
 	_log_mutex.lock()

--- a/addons/godot_mcp/tools/node_tools_native.gd
+++ b/addons/godot_mcp/tools/node_tools_native.gd
@@ -488,28 +488,28 @@ func _convert_value_for_property(node: Node, property_name: String, value: Varia
 			if value is Dictionary:
 				return Vector2(float(value.get("x", 0.0)), float(value.get("y", 0.0)))
 			if value is String:
-				var parts: PackedStringArray = value.replace("(", "").replace(")", "").replace(" ", "").split(",")
+				var parts: PackedStringArray = _strip_constructor_prefix(value).replace("(", "").replace(")", "").replace(" ", "").split(",")
 				if parts.size() >= 2:
 					return Vector2(float(parts[0]), float(parts[1]))
 		TYPE_VECTOR2I:
 			if value is Dictionary:
 				return Vector2i(int(value.get("x", 0)), int(value.get("y", 0)))
 			if value is String:
-				var parts: PackedStringArray = value.replace("(", "").replace(")", "").replace(" ", "").split(",")
+				var parts: PackedStringArray = _strip_constructor_prefix(value).replace("(", "").replace(")", "").replace(" ", "").split(",")
 				if parts.size() >= 2:
 					return Vector2i(int(parts[0]), int(parts[1]))
 		TYPE_VECTOR3:
 			if value is Dictionary:
 				return Vector3(float(value.get("x", 0.0)), float(value.get("y", 0.0)), float(value.get("z", 0.0)))
 			if value is String:
-				var parts: PackedStringArray = value.replace("(", "").replace(")", "").replace(" ", "").split(",")
+				var parts: PackedStringArray = _strip_constructor_prefix(value).replace("(", "").replace(")", "").replace(" ", "").split(",")
 				if parts.size() >= 3:
 					return Vector3(float(parts[0]), float(parts[1]), float(parts[2]))
 		TYPE_VECTOR3I:
 			if value is Dictionary:
 				return Vector3i(int(value.get("x", 0)), int(value.get("y", 0)), int(value.get("z", 0)))
 			if value is String:
-				var parts: PackedStringArray = value.replace("(", "").replace(")", "").replace(" ", "").split(",")
+				var parts: PackedStringArray = _strip_constructor_prefix(value).replace("(", "").replace(")", "").replace(" ", "").split(",")
 				if parts.size() >= 3:
 					return Vector3i(int(parts[0]), int(parts[1]), int(parts[2]))
 		TYPE_COLOR:
@@ -548,6 +548,16 @@ func _convert_value_for_property(node: Node, property_name: String, value: Varia
 				return t
 	
 	return value
+
+static func _strip_constructor_prefix(value: String) -> String:
+	var trimmed: String = value.strip_edges()
+	var open_index: int = trimmed.find("(")
+	if open_index <= 0:
+		return trimmed
+	var prefix: String = trimmed.substr(0, open_index)
+	if prefix.is_valid_identifier():
+		return trimmed.substr(open_index)
+	return trimmed
 
 static func _serialize_value(value: Variant) -> Variant:
 	if value == null:

--- a/docs/current/tools-reference.md
+++ b/docs/current/tools-reference.md
@@ -18,7 +18,7 @@
 
 ## 工具概述
 
-Godot MCP Native 实现了 **50 个工具**，分为 6 大类：
+Godot MCP Native 实现了 **62 个工具**，分为 6 大类：
 
 | 类别 | 工具数量 | 源文件 | 用途 |
 |------|----------|--------|------|
@@ -26,7 +26,7 @@ Godot MCP Native 实现了 **50 个工具**，分为 6 大类：
 | [Script Tools](#script-tools) | 9 | `script_tools_native.gd` | 脚本管理（读取、创建、修改、分析、附加、验证、搜索） |
 | [Scene Tools](#scene-tools) | 6 | `scene_tools_native.gd` | 场景管理（创建、保存、打开） |
 | [Editor Tools](#editor-tools) | 8 | `editor_tools_native.gd` | 编辑器操作（运行、停止、获取状态、截图、信号、重载） |
-| [Debug Tools](#debug-tools) | 6 | `debug_tools_native.gd` | 调试和日志（日志获取、清除、脚本执行、性能监控） |
+| [Debug Tools](#debug-tools) | 18 | `debug_tools_native.gd` | 调试和日志（日志获取、脚本执行、调试会话、断点、栈帧/变量读取、Profiler、运行时探针） |
 | [Project Tools](#project-tools) | 5 | `project_tools_native.gd` | 项目配置（信息、设置、结构） |
 
 ### 工具调用格式
@@ -1275,9 +1275,242 @@ Godot MCP Native 实现了 **50 个工具**，分为 6 大类：
 
 ---
 
+### 46. get_debugger_sessions
+
+列出 Godot 编辑器调试会话及其状态。
+
+**参数**：无
+
+**返回值**：
+| 字段 | 类型 | 描述 |
+|------|------|------|
+| `sessions` | Array[Dictionary] | 调试会话列表 |
+| `count` | int | 会话数量 |
+
+**每个会话**：
+| 字段 | 类型 | 描述 |
+|------|------|------|
+| `session_id` | int | 会话 ID |
+| `active` | boolean | 是否连接到运行中的实例 |
+| `breaked` | boolean | 是否处于断点暂停状态 |
+| `debuggable` | boolean | 当前实例是否可脚本调试 |
+
+---
+
+### 47. set_debugger_breakpoint
+
+通过 Godot `EditorDebuggerSession` 启用或禁用脚本断点。
+
+**参数**：
+| 参数 | 类型 | 必需 | 描述 |
+|------|------|------|------|
+| `path` | string | 是 | 脚本路径，如 `res://player.gd` |
+| `line` | int | 是 | 1-based 行号 |
+| `enabled` | boolean | 是 | 是否启用断点 |
+| `session_id` | int | 否 | 目标调试会话，默认 `-1` 表示全部会话 |
+
+**返回值**：
+| 字段 | 类型 | 描述 |
+|------|------|------|
+| `status` | string | `success`、`no_sessions` 或错误 |
+| `sessions_updated` | int | 更新的会话数量 |
+
+---
+
+### 48. send_debugger_message
+
+向活动调试会话中的运行实例发送自定义 `EngineDebugger` 消息。运行时脚本可通过 `EngineDebugger.register_message_capture()` 接收。
+
+**参数**：
+| 参数 | 类型 | 必需 | 描述 |
+|------|------|------|------|
+| `message` | string | 是 | 消息名，如 `mcp:ping` |
+| `data` | Array | 否 | 附加数据 |
+| `session_id` | int | 否 | 目标调试会话，默认 `-1` 表示全部活动会话 |
+
+**返回值**：
+| 字段 | 类型 | 描述 |
+|------|------|------|
+| `status` | string | `success`、`no_active_sessions` 或错误 |
+| `sessions_updated` | int | 接收消息的活动会话数量 |
+
+---
+
+### 49. toggle_debugger_profiler
+
+在活动调试会话中切换运行时 `EngineProfiler`。
+
+**参数**：
+| 参数 | 类型 | 必需 | 描述 |
+|------|------|------|------|
+| `profiler` | string | 是 | Profiler 名称 |
+| `enabled` | boolean | 是 | 是否启用 |
+| `data` | Array | 否 | 传给 profiler 的附加参数 |
+| `session_id` | int | 否 | 目标调试会话，默认 `-1` 表示全部活动会话 |
+
+**返回值**：
+| 字段 | 类型 | 描述 |
+|------|------|------|
+| `status` | string | `success`、`no_active_sessions` 或错误 |
+| `sessions_updated` | int | 更新的活动会话数量 |
+
+---
+
+### 50. get_debugger_messages
+
+读取 `MCPDebuggerBridge` 从运行实例捕获的自定义调试消息。
+
+**参数**：
+| 参数 | 类型 | 必需 | 描述 |
+|------|------|------|------|
+| `count` | int | 否 | 最大返回条数（默认 `100`） |
+| `offset` | int | 否 | 跳过条数（默认 `0`） |
+| `order` | string | 否 | `desc` 或 `asc`，默认 `desc` |
+
+**返回值**：
+| 字段 | 类型 | 描述 |
+|------|------|------|
+| `messages` | Array[Dictionary] | 捕获消息 |
+| `count` | int | 返回数量 |
+| `total_available` | int | 可用消息总数 |
+
+---
+
+### 51. add_debugger_capture_prefix
+
+允许 debugger bridge 捕获更多 `EngineDebugger` 消息前缀。默认捕获 `mcp`。
+
+**参数**：
+| 参数 | 类型 | 必需 | 描述 |
+|------|------|------|------|
+| `prefix` | string | 是 | 前缀，不包含冒号；`*` 表示捕获全部 |
+
+**返回值**：
+| 字段 | 类型 | 描述 |
+|------|------|------|
+| `status` | string | `success` |
+| `prefixes` | Array[string] | 当前捕获前缀列表 |
+
+---
+
+### 52. get_debug_stack_frames
+
+返回最近捕获到的脚本栈帧，并可向已暂停会话请求刷新 `get_stack_dump`。通常先使用 `request_debug_break` 让运行实例进入暂停状态，再调用本工具。
+
+**参数**：
+| 参数 | 类型 | 必需 | 描述 |
+|------|------|------|------|
+| `refresh` | boolean | 否 | 是否先请求刷新栈帧；默认 `true` |
+| `session_id` | int | 否 | 目标调试会话，默认 `-1` 表示全部活动会话 |
+
+**返回值**：
+| 字段 | 类型 | 描述 |
+|------|------|------|
+| `frames` | Array[Dictionary] | 栈帧列表，包含 `frame`、`file`、`function`、`line` |
+| `count` | int | 栈帧数量 |
+| `refresh_result` | Dictionary | 刷新请求结果 |
+
+---
+
+### 53. get_debug_stack_variables
+
+返回指定栈帧最近捕获到的局部变量、成员变量和全局变量，并可向已暂停会话请求刷新 `get_stack_frame_vars`。
+
+**参数**：
+| 参数 | 类型 | 必需 | 描述 |
+|------|------|------|------|
+| `frame` | int | 否 | 栈帧索引，默认 `0` |
+| `refresh` | boolean | 否 | 是否先请求刷新变量；默认 `true` |
+| `session_id` | int | 否 | 目标调试会话，默认 `-1` 表示全部活动会话 |
+
+**返回值**：
+| 字段 | 类型 | 描述 |
+|------|------|------|
+| `frame` | int | 栈帧索引 |
+| `variables` | Array[Dictionary] | 变量列表，包含 `name`、`scope`、`type`、`value` 和 `raw` |
+| `count` | int | 变量数量 |
+| `refresh_result` | Dictionary | 刷新请求结果 |
+
+---
+
+### 54. install_runtime_probe
+
+向当前场景添加 `MCPRuntimeProbe` 节点。运行项目后，该节点会注册 `EngineDebugger` capture，并响应 `mcp:ping`、`mcp:get_runtime_info`、`mcp:get_scene_tree`、`mcp:inspect_node`。
+
+**参数**：
+| 参数 | 类型 | 必需 | 描述 |
+|------|------|------|------|
+| `node_name` | string | 否 | 探针节点名，默认 `MCPRuntimeProbe` |
+| `persistent` | boolean | 否 | 是否设置 owner 以便保存到场景；默认 `true` |
+
+**返回值**：
+| 字段 | 类型 | 描述 |
+|------|------|------|
+| `status` | string | `success` 或 `already_installed` |
+| `node_path` | string | 探针节点路径 |
+| `persistent` | boolean | 是否为可保存节点 |
+
+---
+
+### 55. remove_runtime_probe
+
+从当前场景移除 `MCPRuntimeProbe` 节点。
+
+**参数**：
+| 参数 | 类型 | 必需 | 描述 |
+|------|------|------|------|
+| `node_name` | string | 否 | 探针节点名，默认 `MCPRuntimeProbe` |
+
+**返回值**：
+| 字段 | 类型 | 描述 |
+|------|------|------|
+| `status` | string | `success` 或 `not_installed` |
+| `removed_node` | string | 被移除的节点路径 |
+
+---
+
+### 56. request_debug_break
+
+请求已安装的 `MCPRuntimeProbe` 调用 `EngineDebugger.debug()`，让运行实例进入 Godot 脚本调试暂停循环。
+
+**参数**：
+| 参数 | 类型 | 必需 | 描述 |
+|------|------|------|------|
+| `session_id` | int | 否 | 目标调试会话，默认 `-1` 表示全部活动会话 |
+
+**返回值**：
+| 字段 | 类型 | 描述 |
+|------|------|------|
+| `status` | string | `success`、`no_active_sessions` 或错误 |
+| `sessions_updated` | int | 接收请求的活动会话数量 |
+
+---
+
+### 57. send_debug_command
+
+向已暂停的 Godot 调试循环发送命令。支持 `step`、`next`、`out`、`continue`、`get_stack_dump`、`get_stack_frame_vars`。
+
+**参数**：
+| 参数 | 类型 | 必需 | 描述 |
+|------|------|------|------|
+| `command` | string | 是 | 调试命令 |
+| `data` | Array | 否 | 命令参数，如 `get_stack_frame_vars` 使用 `[0]` 请求第 0 帧变量 |
+| `session_id` | int | 否 | 目标调试会话，默认 `-1` 表示全部活动会话 |
+
+**返回值**：
+| 字段 | 类型 | 描述 |
+|------|------|------|
+| `status` | string | `success`、`no_active_sessions` 或错误 |
+| `sessions_updated` | int | 接收命令的活动会话数量 |
+| `note` | string | 对 stack 命令的 Godot API 限制说明 |
+
+**提示**：读取栈帧和变量时优先使用 `get_debug_stack_frames` / `get_debug_stack_variables`；它们会监听内置 `ScriptEditorDebugger` 信号并返回结构化数据。
+
+---
+
 ## Project Tools
 
-### 46. get_project_info
+### 58. get_project_info
 
 获取项目的基本信息。
 
@@ -1296,7 +1529,7 @@ Godot MCP Native 实现了 **50 个工具**，分为 6 大类：
 
 ---
 
-### 47. get_project_settings
+### 59. get_project_settings
 
 获取项目的设置值。
 
@@ -1315,7 +1548,7 @@ Godot MCP Native 实现了 **50 个工具**，分为 6 大类：
 
 ---
 
-### 48. list_project_resources
+### 60. list_project_resources
 
 列出项目中的所有资源文件。
 
@@ -1337,7 +1570,7 @@ Godot MCP Native 实现了 **50 个工具**，分为 6 大类：
 
 ---
 
-### 49. create_resource
+### 61. create_resource
 
 创建新的 Godot 资源文件。
 
@@ -1359,7 +1592,7 @@ Godot MCP Native 实现了 **50 个工具**，分为 6 大类：
 
 ---
 
-### 50. get_project_structure
+### 62. get_project_structure
 
 获取项目的目录结构和文件类型统计。
 
@@ -1489,7 +1722,7 @@ Godot MCP Native 实现了 **50 个工具**，分为 6 大类：
 
 ## 总结
 
-本手册详细说明了 Godot MCP Native 项目的所有 50 个工具。每个工具都有清晰的参数说明、返回值描述和注解信息。
+本手册详细说明了 Godot MCP Native 项目的所有 62 个工具。每个工具都有清晰的参数说明、返回值描述和注解信息。
 
 **提示**：
 - 使用 `tools/list` 方法获取所有工具的实时列表和完整 JSON Schema
@@ -1502,4 +1735,3 @@ Godot MCP Native 实现了 **50 个工具**，分为 6 大类：
 - `set_anchor_preset` 快速设置 Control 节点的布局锚点
 - `execute_editor_script` 适合复杂脚本执行，`execute_script` 适合简单表达式求值
 - 所有文件路径都经过 `PathValidator` 安全验证
-

--- a/test/integration/test_runtime_probe_flow.py
+++ b/test/integration/test_runtime_probe_flow.py
@@ -1,0 +1,245 @@
+import json
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GODOT_EXE = Path(r"C:\SourceCode\Godot_v4.6.2-stable_mono_win64\Godot_v4.6.2-stable_mono_win64_console.exe")
+MCP_URL = "http://127.0.0.1:9080/mcp"
+
+
+def rpc_call(method: str, params: dict | None = None, request_id: int = 1) -> dict:
+    payload = {
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": params or {},
+        "id": request_id,
+    }
+    request = urllib.request.Request(
+        MCP_URL,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=15) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def tool_call(name: str, arguments: dict | None = None, request_id: int = 100) -> dict:
+    response = rpc_call(
+        "tools/call",
+        {"name": name, "arguments": arguments or {}},
+        request_id=request_id,
+    )
+    result = response["result"]
+    if result.get("isError"):
+        raise AssertionError(f"Tool {name} failed: {result['content'][0]['text']}")
+    if "structuredContent" in result:
+        return result["structuredContent"]
+    return json.loads(result["content"][0]["text"])
+
+
+def poll_tool(name: str, arguments: dict, predicate, timeout_seconds: float = 10.0, start_request_id: int = 1000) -> dict:
+    deadline = time.time() + timeout_seconds
+    request_id = start_request_id
+    last_result = None
+    while time.time() < deadline:
+        last_result = tool_call(name, arguments, request_id=request_id)
+        if predicate(last_result):
+            return last_result
+        time.sleep(0.25)
+        request_id += 1
+    raise AssertionError(f"{name} did not reach expected state. Last result: {last_result}")
+
+
+def wait_for_server(timeout_seconds: float = 30.0) -> None:
+    deadline = time.time() + timeout_seconds
+    while time.time() < deadline:
+        try:
+            rpc_call("tools/list")
+            return
+        except Exception:
+            time.sleep(0.5)
+    raise TimeoutError("Timed out waiting for MCP server on port 9080")
+
+
+def main() -> int:
+    args = [
+        str(GODOT_EXE),
+        "--editor",
+        "--headless",
+        "--path",
+        str(REPO_ROOT),
+        "--",
+        "--mcp-server",
+    ]
+    process = subprocess.Popen(
+        args,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        cwd=REPO_ROOT,
+    )
+
+    try:
+        wait_for_server()
+        tools_response = rpc_call("tools/list")
+        tool_names = {tool["name"] for tool in tools_response["result"]["tools"]}
+
+        expected_tools = {
+            "get_runtime_info",
+            "get_runtime_scene_tree",
+            "inspect_runtime_node",
+            "update_runtime_node_property",
+            "call_runtime_node_method",
+            "evaluate_runtime_expression",
+            "await_runtime_condition",
+            "assert_runtime_condition",
+        }
+        missing = sorted(expected_tools - tool_names)
+        if missing:
+            raise AssertionError(f"Missing expected runtime tools: {missing}")
+
+        project_info = tool_call("get_project_info", request_id=2)
+        main_scene = project_info["main_scene"]
+        if not main_scene:
+            raise AssertionError("Project has no main scene configured")
+
+        open_scene_result = tool_call("open_scene", {"scene_path": main_scene}, request_id=3)
+        if open_scene_result.get("status") != "success":
+            raise AssertionError(f"open_scene failed: {open_scene_result}")
+
+        install_result = tool_call(
+            "install_runtime_probe",
+            {"node_name": "MCPRuntimeProbe", "persistent": True},
+            request_id=4,
+        )
+        if install_result.get("status") not in {"success", "already_installed"}:
+            raise AssertionError(f"install_runtime_probe failed: {install_result}")
+
+        run_result = tool_call("run_project", {}, request_id=5)
+        if run_result.get("status") != "success":
+            raise AssertionError(f"run_project failed: {run_result}")
+
+        deadline = time.time() + 15.0
+        while time.time() < deadline:
+            sessions = tool_call("get_debugger_sessions", {}, request_id=6)
+            if sessions["count"] > 0 and any(session.get("active") for session in sessions["sessions"]):
+                break
+            time.sleep(0.5)
+        else:
+            raise AssertionError("Debugger session never became active")
+
+        runtime_info = poll_tool(
+            "get_runtime_info",
+            {"timeout_ms": 2000},
+            lambda result: result.get("status") in {"success", "stale"} and "node_count" in result,
+            timeout_seconds=12.0,
+            start_request_id=7,
+        )
+        if runtime_info["node_count"] <= 0:
+            raise AssertionError(f"Unexpected runtime_info payload: {runtime_info}")
+
+        scene_tree = poll_tool(
+            "get_runtime_scene_tree",
+            {"max_depth": 2, "timeout_ms": 2000},
+            lambda result: result.get("status") == "success" and "child_count" in result,
+            timeout_seconds=8.0,
+            start_request_id=8,
+        )
+        if scene_tree.get("child_count", -1) < 0:
+            raise AssertionError(f"Invalid scene tree response: {scene_tree}")
+
+        current_scene_path = runtime_info["current_scene"]
+        inspect_result = poll_tool(
+            "inspect_runtime_node",
+            {"node_path": current_scene_path, "timeout_ms": 2000},
+            lambda result: result.get("status") == "success" and result.get("path") == current_scene_path,
+            timeout_seconds=8.0,
+            start_request_id=9,
+        )
+
+        update_result = poll_tool(
+            "update_runtime_node_property",
+            {
+                "node_path": current_scene_path,
+                "property_name": "process_priority",
+                "property_value": 7,
+                "timeout_ms": 2000,
+            },
+            lambda result: result.get("status") == "success" and result.get("new_value") == 7,
+            timeout_seconds=8.0,
+            start_request_id=10,
+        )
+
+        eval_result = poll_tool(
+            "evaluate_runtime_expression",
+            {
+                "expression": "process_priority",
+                "node_path": current_scene_path,
+                "timeout_ms": 2000,
+            },
+            lambda result: result.get("status") == "success" and result.get("value") == 7,
+            timeout_seconds=8.0,
+            start_request_id=11,
+        )
+
+        call_result = poll_tool(
+            "call_runtime_node_method",
+            {
+                "node_path": current_scene_path,
+                "method_name": "get_child_count",
+                "arguments": [],
+                "timeout_ms": 2000,
+            },
+            lambda result: result.get("status") == "success" and result.get("result", -1) >= 0,
+            timeout_seconds=8.0,
+            start_request_id=12,
+        )
+
+        assert_result = poll_tool(
+            "assert_runtime_condition",
+            {
+                "expression": "process_priority == 7",
+                "node_path": current_scene_path,
+                "timeout_ms": 1000,
+                "poll_interval_ms": 100,
+                "description": "current scene process_priority should update to 7",
+            },
+            lambda result: result.get("status") == "success",
+            timeout_seconds=8.0,
+            start_request_id=13,
+        )
+
+        stop_result = tool_call("stop_project", {}, request_id=14)
+        if stop_result.get("status") != "success":
+            raise AssertionError(f"stop_project failed: {stop_result}")
+
+        remove_result = tool_call(
+            "remove_runtime_probe",
+            {"node_name": "MCPRuntimeProbe"},
+            request_id=15,
+        )
+        if remove_result.get("status") not in {"success", "not_installed"}:
+            raise AssertionError(f"remove_runtime_probe failed: {remove_result}")
+
+        save_cleanup = tool_call("save_scene", {}, request_id=16)
+        if save_cleanup.get("status") != "success":
+            raise AssertionError(f"cleanup save_scene failed: {save_cleanup}")
+
+        print("runtime probe flow verified")
+        return 0
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=10)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/unit/test_mcp_debugger_bridge.gd
+++ b/test/unit/test_mcp_debugger_bridge.gd
@@ -1,0 +1,50 @@
+extends "res://addons/gut/test.gd"
+
+var _bridge: MCPDebuggerBridge = null
+
+func before_each():
+	_bridge = load("res://addons/godot_mcp/native_mcp/mcp_debugger_bridge.gd").new()
+
+func after_each():
+	_bridge = null
+
+func test_get_sessions_info_empty_before_registered_with_editor():
+	var sessions: Array = _bridge.get_sessions_info()
+	assert_eq(sessions.size(), 0, "Unregistered bridge should have no debugger sessions")
+
+func test_for_each_session_returns_no_sessions_when_unregistered():
+	var result: Dictionary = _bridge.set_breakpoint("res://player.gd", 1, true)
+	assert_eq(result.status, "no_sessions", "Unregistered bridge should report no sessions")
+	assert_eq(result.sessions_updated, 0, "No sessions should be updated")
+
+func test_capture_prefix_defaults_to_mcp():
+	assert_true(_bridge._has_capture("mcp"), "Bridge should capture mcp-prefixed debugger messages by default")
+	assert_false(_bridge._has_capture("other"), "Bridge should ignore unrelated prefixes by default")
+
+func test_add_capture_prefix():
+	_bridge.add_capture_prefix("ai")
+	assert_true(_bridge._has_capture("ai"), "Added prefix should be captured")
+
+func test_capture_stores_messages():
+	var captured: bool = _bridge._capture("mcp:test", ["hello"], 2)
+	assert_true(captured, "Capture should report handled")
+	var result: Dictionary = _bridge.get_captured_messages(10, 0, "asc")
+	assert_eq(result.count, 1, "Should return one captured message")
+	assert_eq(result.messages[0].session_id, 2, "Should preserve session id")
+	assert_eq(result.messages[0].message, "mcp:test", "Should preserve message name")
+
+func test_stack_dump_signal_updates_latest_frames():
+	var frames: Array = [{"frame": 0, "file": "res://player.gd", "function": "_ready", "line": 12}]
+	_bridge._on_stack_dump(frames)
+	assert_eq(_bridge.get_latest_stack_dump().size(), 1, "Should store latest stack frames")
+	assert_eq(_bridge.get_latest_stack_dump()[0].file, "res://player.gd", "Should preserve stack frame data")
+
+func test_stack_frame_var_decodes_variable_payload():
+	_bridge._on_stack_frame_vars(1)
+	_bridge._on_stack_frame_var(["speed", 0, TYPE_FLOAT, 12.5])
+	var variables: Array = _bridge.get_latest_stack_variables(0)
+	assert_eq(variables.size(), 1, "Should store latest stack variable")
+	assert_eq(variables[0].name, "speed", "Should decode variable name")
+	assert_eq(variables[0].scope, "local", "Should decode variable scope")
+	assert_eq(variables[0].type, "float", "Should decode variable type")
+	assert_eq(variables[0].value, 12.5, "Should preserve variable value")

--- a/test/unit/test_mcp_debugger_bridge.gd.uid
+++ b/test/unit/test_mcp_debugger_bridge.gd.uid
@@ -1,0 +1,1 @@
+uid://dv1bwb2bwjcgc

--- a/test/unit/test_node_tools_convert.gd
+++ b/test/unit/test_node_tools_convert.gd
@@ -57,6 +57,12 @@ func test_convert_value_for_property_vector3_from_string():
 	assert_eq(result, Vector3(1, 2, 3), "Should convert string to Vector3")
 	node.free()
 
+func test_convert_value_for_property_vector3_from_constructor_string():
+	var node: Node3D = Node3D.new()
+	var result: Variant = _node_tools._convert_value_for_property(node, "position", "Vector3(1, 2, 3)")
+	assert_eq(result, Vector3(1, 2, 3), "Should convert Vector3 constructor-like string to Vector3")
+	node.free()
+
 func test_convert_value_for_property_vector2_from_dict():
 	var node: Node2D = Node2D.new()
 	var result: Variant = _node_tools._convert_value_for_property(node, "position", {"x": 5.0, "y": 10.0})

--- a/test/unit/tools/test_debug_tools.gd
+++ b/test/unit/tools/test_debug_tools.gd
@@ -58,3 +58,51 @@ func test_mutex_thread_safety():
 	mutex.lock()
 	mutex.unlock()
 	assert_true(true, "Mutex lock/unlock should not crash")
+
+func test_set_debugger_breakpoint_missing_path():
+	var debug_tools: RefCounted = load("res://addons/godot_mcp/tools/debug_tools_native.gd").new()
+	var result: Dictionary = debug_tools._tool_set_debugger_breakpoint({"line": 1, "enabled": true})
+	assert_has(result, "error", "Should return error for missing path")
+	assert_true(str(result.error).contains("path"), "Error should mention path")
+
+func test_set_debugger_breakpoint_invalid_line():
+	var debug_tools: RefCounted = load("res://addons/godot_mcp/tools/debug_tools_native.gd").new()
+	var result: Dictionary = debug_tools._tool_set_debugger_breakpoint({"path": "res://player.gd", "line": 0, "enabled": true})
+	assert_has(result, "error", "Should return error for invalid line")
+	assert_true(str(result.error).contains("line"), "Error should mention line")
+
+func test_send_debugger_message_missing_message():
+	var debug_tools: RefCounted = load("res://addons/godot_mcp/tools/debug_tools_native.gd").new()
+	var result: Dictionary = debug_tools._tool_send_debugger_message({})
+	assert_has(result, "error", "Should return error for missing message")
+	assert_true(str(result.error).contains("message"), "Error should mention message")
+
+func test_toggle_debugger_profiler_missing_profiler():
+	var debug_tools: RefCounted = load("res://addons/godot_mcp/tools/debug_tools_native.gd").new()
+	var result: Dictionary = debug_tools._tool_toggle_debugger_profiler({"enabled": true})
+	assert_has(result, "error", "Should return error for missing profiler")
+	assert_true(str(result.error).contains("profiler"), "Error should mention profiler")
+
+func test_add_debugger_capture_prefix_missing_prefix():
+	var debug_tools: RefCounted = load("res://addons/godot_mcp/tools/debug_tools_native.gd").new()
+	var result: Dictionary = debug_tools._tool_add_debugger_capture_prefix({})
+	assert_has(result, "error", "Should return error for missing prefix")
+	assert_true(str(result.error).contains("prefix"), "Error should mention prefix")
+
+func test_install_runtime_probe_empty_node_name():
+	var debug_tools: RefCounted = load("res://addons/godot_mcp/tools/debug_tools_native.gd").new()
+	var result: Dictionary = debug_tools._tool_install_runtime_probe({"node_name": ""})
+	assert_has(result, "error", "Should return error for empty node_name before editing scene")
+	assert_true(str(result.error).contains("Editor interface") or str(result.error).contains("node_name"), "Error should be explicit")
+
+func test_send_debug_command_rejects_unknown_command():
+	var debug_tools: RefCounted = load("res://addons/godot_mcp/tools/debug_tools_native.gd").new()
+	var result: Dictionary = debug_tools._tool_send_debug_command({"command": "unsupported"})
+	assert_has(result, "error", "Should return error for unsupported command")
+	assert_true(str(result.error).contains("Unsupported"), "Error should mention unsupported command")
+
+func test_get_debug_stack_variables_rejects_negative_frame():
+	var debug_tools: RefCounted = load("res://addons/godot_mcp/tools/debug_tools_native.gd").new()
+	var result: Dictionary = debug_tools._tool_get_debug_stack_variables({"frame": -1})
+	assert_has(result, "error", "Should return error for invalid frame")
+	assert_true(str(result.error).contains("frame"), "Error should mention frame")


### PR DESCRIPTION
## Summary

Adds native debugger integration so AI clients can inspect and control a running Godot project more completely from MCP.

## Changes

- Fix Vector2/Vector3 property conversion for constructor-style strings such as `Vector3(1, 2, 3)`.
- Add an `EditorDebuggerPlugin` bridge for debugger sessions, breakpoints, messages, profiler toggles, stack frames, and stack variables.
- Add an `MCPRuntimeProbe` node that can be installed into a scene to answer runtime debugger messages and request a script debug break.
- Add MCP debug tools for runtime probe install/remove, debug break requests, stack frame reads, and stack variable reads.
- Update README and tools reference from 60 tools to 62 tools.
- Add focused unit coverage for conversion, debugger bridge state, and debug tool validation.

## Validation

- `tools/list` returned 62 tools.
- `validate_script` passed with 0 errors / 0 warnings for the changed production scripts.
- Verified `update_node_property` writes `Vector3(1, 2, 3)` as `(1.0, 2.0, 3.0)`.
- Verified runtime chain in Godot 4.6.2 mono: install runtime probe, run project, receive `mcp:probe_ready`/`mcp:pong`, request debug break, observe `breaked=true` and `debuggable=true`, read stack frame and stack variables.
- `git diff --check` passed.

## Notes

The repository does not include `addons/gut`, so the GUT test suite could not be executed locally; tests were added but not run end-to-end.
