### PR TITLE
[codex] Refresh tool docs and add quiet vibe coding mode

### DIFF
--- a/addons/godot_mcp/mcp_server_native.gd
+++ b/addons/godot_mcp/mcp_server_native.gd
@@ -13,6 +13,11 @@ extends EditorPlugin
 		auto_start = value
 		notify_property_list_changed()
 
+@export var vibe_coding_mode: bool = true:
+	set(value):
+		vibe_coding_mode = value
+		notify_property_list_changed()
+
 @export var transport_mode: String = "http":
 	set(value):
 		if value == "stdio" or value == "http":
@@ -311,6 +316,12 @@ func _get_property_list() -> Array:
 	
 	properties.append({
 		"name": "auto_start",
+		"type": TYPE_BOOL,
+		"usage": PROPERTY_USAGE_DEFAULT
+	})
+
+	properties.append({
+		"name": "vibe_coding_mode",
 		"type": TYPE_BOOL,
 		"usage": PROPERTY_USAGE_DEFAULT
 	})

--- a/addons/godot_mcp/tools/editor_tools_native.gd
+++ b/addons/godot_mcp/tools/editor_tools_native.gd
@@ -5,6 +5,8 @@
 class_name EditorToolsNative
 extends RefCounted
 
+const VIBE_CODING_POLICY = preload("res://addons/godot_mcp/utils/vibe_coding_policy.gd")
+
 var _editor_interface: EditorInterface = null
 var _editor_operation_in_progress: bool = false
 
@@ -19,6 +21,13 @@ func _get_editor_interface() -> EditorInterface:
 		if plugin and plugin.has_method("get_editor_interface"):
 			return plugin.get_editor_interface()
 	return null
+
+func _is_vibe_coding_mode() -> bool:
+	if Engine.has_meta("GodotMCPPlugin"):
+		var plugin = Engine.get_meta("GodotMCPPlugin")
+		if plugin and plugin.get("vibe_coding_mode") != null:
+			return bool(plugin.vibe_coding_mode)
+	return true
 
 func _get_user_scene_root() -> Node:
 	var editor_interface: EditorInterface = _get_editor_interface()
@@ -159,6 +168,11 @@ func _register_run_project(server_core: RefCounted) -> void:
 			"scene_path": {
 				"type": "string",
 				"description": "Optional path to a specific scene to run. If not provided, runs the main scene."
+			},
+			"allow_window": {
+				"type": "boolean",
+				"description": "Allow this call to open or control the runtime window when Vibe Coding mode is enabled.",
+				"default": false
 			}
 		}
 	}
@@ -187,6 +201,10 @@ func _register_run_project(server_core: RefCounted) -> void:
 						  "core", "Editor")
 
 func _tool_run_project(params: Dictionary) -> Dictionary:
+	var policy_result: Dictionary = VIBE_CODING_POLICY.evaluate_runtime_window(_is_vibe_coding_mode(), params)
+	if policy_result.get("blocked", false):
+		return policy_result
+
 	var editor_interface: EditorInterface = _get_editor_interface()
 	if not editor_interface:
 		return {"error": "Editor interface not available"}
@@ -223,7 +241,13 @@ func _register_stop_project(server_core: RefCounted) -> void:
 	# inputSchema
 	var input_schema: Dictionary = {
 		"type": "object",
-		"properties": {}
+		"properties": {
+			"allow_window": {
+				"type": "boolean",
+				"description": "Allow this call to control the runtime window when Vibe Coding mode is enabled.",
+				"default": false
+			}
+		}
 	}
 	
 	# outputSchema
@@ -250,6 +274,10 @@ func _register_stop_project(server_core: RefCounted) -> void:
 						  "core", "Editor")
 
 func _tool_stop_project(params: Dictionary) -> Dictionary:
+	var policy_result: Dictionary = VIBE_CODING_POLICY.evaluate_runtime_window(_is_vibe_coding_mode(), params)
+	if policy_result.get("blocked", false):
+		return policy_result
+
 	var editor_interface: EditorInterface = _get_editor_interface()
 	if not editor_interface:
 		return {"error": "Editor interface not available"}
@@ -355,6 +383,11 @@ func _register_select_node(server_core: RefCounted) -> void:
 				"type": "boolean",
 				"description": "Whether to clear the existing editor selection before selecting the node. Default is true.",
 				"default": true
+			},
+			"allow_ui_focus": {
+				"type": "boolean",
+				"description": "Allow this call to change editor selection/focus when Vibe Coding mode is enabled.",
+				"default": false
 			}
 		},
 		"required": ["node_path"]
@@ -383,6 +416,10 @@ func _register_select_node(server_core: RefCounted) -> void:
 						  "supplementary", "Editor-Advanced")
 
 func _tool_select_node(params: Dictionary) -> Dictionary:
+	var policy_result: Dictionary = VIBE_CODING_POLICY.evaluate_editor_focus(_is_vibe_coding_mode(), params)
+	if policy_result.get("blocked", false):
+		return policy_result
+
 	var node_path: String = str(params.get("node_path", "")).strip_edges()
 	if node_path.is_empty():
 		return {"error": "Missing required parameter: node_path"}
@@ -429,6 +466,11 @@ func _register_select_file(server_core: RefCounted) -> void:
 			"file_path": {
 				"type": "string",
 				"description": "Project file path such as 'res://scenes/Main.tscn'."
+			},
+			"allow_ui_focus": {
+				"type": "boolean",
+				"description": "Allow this call to change the editor FileSystem selection when Vibe Coding mode is enabled.",
+				"default": false
 			}
 		},
 		"required": ["file_path"]
@@ -455,6 +497,10 @@ func _register_select_file(server_core: RefCounted) -> void:
 						  "supplementary", "Editor-Advanced")
 
 func _tool_select_file(params: Dictionary) -> Dictionary:
+	var policy_result: Dictionary = VIBE_CODING_POLICY.evaluate_editor_focus(_is_vibe_coding_mode(), params)
+	if policy_result.get("blocked", false):
+		return policy_result
+
 	var file_path: String = str(params.get("file_path", "")).strip_edges()
 	if file_path.is_empty():
 		return {"error": "Missing required parameter: file_path"}

--- a/addons/godot_mcp/tools/scene_tools_native.gd
+++ b/addons/godot_mcp/tools/scene_tools_native.gd
@@ -6,6 +6,8 @@
 class_name SceneToolsNative
 extends RefCounted
 
+const VIBE_CODING_POLICY = preload("res://addons/godot_mcp/utils/vibe_coding_policy.gd")
+
 var _editor_interface: EditorInterface = null
 var _scene_operation_in_progress: bool = false
 
@@ -20,6 +22,13 @@ func _get_editor_interface() -> EditorInterface:
 		if plugin and plugin.has_method("get_editor_interface"):
 			return plugin.get_editor_interface()
 	return null
+
+func _is_vibe_coding_mode() -> bool:
+	if Engine.has_meta("GodotMCPPlugin"):
+		var plugin = Engine.get_meta("GodotMCPPlugin")
+		if plugin and plugin.get("vibe_coding_mode") != null:
+			return bool(plugin.vibe_coding_mode)
+	return true
 
 func _get_user_scene_root() -> Node:
 	var editor_interface: EditorInterface = _get_editor_interface()
@@ -265,6 +274,11 @@ func _register_open_scene(server_core: RefCounted) -> void:
 			"scene_path": {
 				"type": "string",
 				"description": "Path to the scene file to open (e.g. 'res://scenes/Main.tscn')"
+			},
+			"allow_ui_focus": {
+				"type": "boolean",
+				"description": "Allow this call to change the active editor scene when Vibe Coding mode is enabled.",
+				"default": false
 			}
 		},
 		"required": ["scene_path"]
@@ -295,6 +309,10 @@ func _register_open_scene(server_core: RefCounted) -> void:
 						  "core", "Scene")
 
 func _tool_open_scene(params: Dictionary) -> Dictionary:
+	var policy_result: Dictionary = VIBE_CODING_POLICY.evaluate_editor_focus(_is_vibe_coding_mode(), params)
+	if policy_result.get("blocked", false):
+		return policy_result
+
 	if _scene_operation_in_progress:
 		return {"error": "Scene operation in progress, please retry"}
 	_scene_operation_in_progress = true
@@ -673,6 +691,11 @@ func _register_close_scene_tab(server_core: RefCounted) -> void:
 			"scene_path": {
 				"type": "string",
 				"description": "Optional scene path to close. If omitted, closes the currently active scene."
+			},
+			"allow_ui_focus": {
+				"type": "boolean",
+				"description": "Allow this call to activate or close editor scene tabs when Vibe Coding mode is enabled.",
+				"default": false
 			}
 		}
 	}
@@ -699,6 +722,10 @@ func _register_close_scene_tab(server_core: RefCounted) -> void:
 						  "supplementary", "Scene-Advanced")
 
 func _tool_close_scene_tab(params: Dictionary) -> Dictionary:
+	var policy_result: Dictionary = VIBE_CODING_POLICY.evaluate_editor_focus(_is_vibe_coding_mode(), params)
+	if policy_result.get("blocked", false):
+		return policy_result
+
 	var editor_interface: EditorInterface = _get_editor_interface()
 	if not editor_interface:
 		return {"error": "Editor interface not available"}

--- a/addons/godot_mcp/tools/script_tools_native.gd
+++ b/addons/godot_mcp/tools/script_tools_native.gd
@@ -5,6 +5,8 @@
 class_name ScriptToolsNative
 extends RefCounted
 
+const VIBE_CODING_POLICY = preload("res://addons/godot_mcp/utils/vibe_coding_policy.gd")
+
 var _editor_interface: EditorInterface = null
 
 func initialize(editor_interface: EditorInterface) -> void:
@@ -18,6 +20,13 @@ func _get_editor_interface() -> EditorInterface:
 		if plugin and plugin.has_method("get_editor_interface"):
 			return plugin.get_editor_interface()
 	return null
+
+func _is_vibe_coding_mode() -> bool:
+	if Engine.has_meta("GodotMCPPlugin"):
+		var plugin = Engine.get_meta("GodotMCPPlugin")
+		if plugin and plugin.get("vibe_coding_mode") != null:
+			return bool(plugin.vibe_coding_mode)
+	return true
 
 # ============================================================================
 # 工具注册
@@ -1700,8 +1709,13 @@ func _register_open_script_at_line(server_core: RefCounted) -> void:
 			},
 			"grab_focus": {
 				"type": "boolean",
-				"description": "Whether the editor should grab focus. Default is true.",
+				"description": "Whether the editor should grab focus. Ignored unless allow_ui_focus=true when Vibe Coding mode is enabled.",
 				"default": true
+			},
+			"allow_ui_focus": {
+				"type": "boolean",
+				"description": "Allow this call to focus the script editor when Vibe Coding mode is enabled.",
+				"default": false
 			}
 		},
 		"required": ["script_path"]
@@ -1754,7 +1768,7 @@ func _tool_open_script_at_line(params: Dictionary) -> Dictionary:
 
 	var line: int = max(1, int(params.get("line", 1)))
 	var column: int = max(0, int(params.get("column", 0)))
-	var grab_focus: bool = params.get("grab_focus", true)
+	var grab_focus: bool = VIBE_CODING_POLICY.should_grab_focus(_is_vibe_coding_mode(), params, true)
 
 	editor_interface.edit_script(script_resource, line - 1, column, grab_focus)
 

--- a/addons/godot_mcp/ui/mcp_panel_native.gd
+++ b/addons/godot_mcp/ui/mcp_panel_native.gd
@@ -8,6 +8,7 @@ var _status_label: Label = null
 var _start_button: Button = null
 var _stop_button: Button = null
 var _auto_start_check: CheckBox = null
+var _vibe_coding_mode_check: CheckBox = null
 var _log_level_option: OptionButton = null
 var _security_level_option: OptionButton = null
 var _log_text_edit: TextEdit = null
@@ -255,6 +256,11 @@ func _create_settings_tab() -> VBoxContainer:
 	_auto_start_check.toggled.connect(_on_auto_start_toggled)
 	content.add_child(_auto_start_check)
 
+	_vibe_coding_mode_check = CheckBox.new()
+	_vibe_coding_mode_check.text = "Vibe Coding / 免打扰模式"
+	_vibe_coding_mode_check.toggled.connect(_on_vibe_coding_mode_toggled)
+	content.add_child(_vibe_coding_mode_check)
+
 	var log_hbox: HBoxContainer = HBoxContainer.new()
 	content.add_child(log_hbox)
 
@@ -420,6 +426,9 @@ func _update_ui_state() -> void:
 		if _auto_start_check:
 			_auto_start_check.button_pressed = _plugin.auto_start
 
+		if _vibe_coding_mode_check:
+			_vibe_coding_mode_check.button_pressed = _plugin.vibe_coding_mode if _plugin.get("vibe_coding_mode") != null else true
+
 		if _log_level_option:
 			_log_level_option.select(_plugin.log_level)
 
@@ -503,6 +512,10 @@ func _on_auto_start_toggled(button_pressed: bool) -> void:
 	if _plugin:
 		_plugin.auto_start = button_pressed
 	_debounce_save()
+
+func _on_vibe_coding_mode_toggled(button_pressed: bool) -> void:
+	if _plugin:
+		_plugin.vibe_coding_mode = button_pressed
 
 func _on_log_level_selected(index: int) -> void:
 	if _plugin:

--- a/addons/godot_mcp/utils/vibe_coding_policy.gd
+++ b/addons/godot_mcp/utils/vibe_coding_policy.gd
@@ -1,0 +1,32 @@
+@tool
+class_name MCPVibeCodingPolicy
+extends RefCounted
+
+const BLOCK_REASON: String = "vibe_coding_mode"
+
+static func evaluate_editor_focus(vibe_coding_mode: bool, params: Dictionary) -> Dictionary:
+	if not vibe_coding_mode:
+		return {"blocked": false}
+	if bool(params.get("allow_ui_focus", false)):
+		return {"blocked": false}
+	return {
+		"blocked": true,
+		"reason": BLOCK_REASON,
+		"error": "Vibe Coding mode is enabled. This tool would change editor focus or selection. Pass allow_ui_focus=true or disable Vibe Coding mode to allow it."
+	}
+
+static func evaluate_runtime_window(vibe_coding_mode: bool, params: Dictionary) -> Dictionary:
+	if not vibe_coding_mode:
+		return {"blocked": false}
+	if bool(params.get("allow_window", false)):
+		return {"blocked": false}
+	return {
+		"blocked": true,
+		"reason": BLOCK_REASON,
+		"error": "Vibe Coding mode is enabled. This tool would open or control a runtime window. Pass allow_window=true or disable Vibe Coding mode to allow it."
+	}
+
+static func should_grab_focus(vibe_coding_mode: bool, params: Dictionary, default_grab_focus: bool = true) -> bool:
+	if vibe_coding_mode and not bool(params.get("allow_ui_focus", false)):
+		return false
+	return bool(params.get("grab_focus", default_grab_focus))

--- a/addons/godot_mcp/utils/vibe_coding_policy.gd.uid
+++ b/addons/godot_mcp/utils/vibe_coding_policy.gd.uid
@@ -1,0 +1,1 @@
+uid://cxe647mxal4kf

--- a/docs/current/tools-reference.md
+++ b/docs/current/tools-reference.md
@@ -29,6 +29,14 @@ Godot MCP Native 实现了 **154 个工具**，分为 6 大类（含核心和补
 | [Debug Tools](#debug-tools) | 3 | 67 | 70 | `debug_tools_native.gd` | 调试和运行时（日志、断点、栈帧、Profiler、运行时探针、动画、音频、着色器、瓦片地图） |
 | [Project Tools](#project-tools) | 5 | 21 | 26 | `project_tools_native.gd` | 项目配置（信息、设置、测试、输入映射、自动加载、全局类、资源诊断） |
 
+### Vibe Coding / 免打扰模式
+
+`vibe_coding_mode` 默认启用。该模式不会关闭 MCP 服务，但会阻止会抢占真人用户编辑器上下文的操作。
+
+- 会切换场景、选择节点/文件或聚焦脚本编辑器的工具，需要本次调用传入 `allow_ui_focus=true`。
+- 会打开或控制运行窗口的工具，需要本次调用传入 `allow_window=true`。
+- 需要人工调试配合 MCP 时，可以在 MCP 面板关闭 `Vibe Coding / 免打扰模式`。
+
 ### 工具调用格式
 
 ```json
@@ -600,6 +608,33 @@ Godot MCP Native 实现了 **154 个工具**，分为 6 大类（含核心和补
 
 ---
 
+### open_script_at_line
+
+打开脚本并定位到指定行/列。默认会尝试在脚本编辑器中定位，但在 `vibe_coding_mode=true` 时不会抢占编辑器焦点，除非本次调用传入 `allow_ui_focus=true`。
+
+**参数**：
+| 参数 | 类型 | 必需 | 描述 |
+|------|------|------|------|
+| `script_path` | string | 是 | 脚本文件路径（如 `res://scripts/player.gd`） |
+| `line` | int | 否 | 1-based 行号（默认 `1`） |
+| `column` | int | 否 | 0-based 列号（默认 `0`） |
+| `grab_focus` | boolean | 否 | 是否让编辑器获取焦点（默认 `true`）。免打扰模式下只有 `allow_ui_focus=true` 时才生效 |
+| `allow_ui_focus` | boolean | 否 | 免打扰模式下允许本次调用聚焦脚本编辑器（默认 `false`） |
+
+**返回值**：
+| 字段 | 类型 | 描述 |
+|------|------|------|
+| `status` | string | `"success"` |
+| `script_path` | string | 打开的脚本路径 |
+| `line` | int | 请求的 1-based 行号 |
+| `column` | int | 请求的 0-based 列号 |
+| `caret_line` | int | Godot 编辑器中的 0-based 光标行 |
+| `caret_column` | int | Godot 编辑器中的 0-based 光标列 |
+
+**注解**：`readOnlyHint=false`, `destructiveHint=false`, `idempotentHint=true`
+
+---
+
 ### 19. create_script
 
 创建新脚本文件，支持模板和自动附加到节点。
@@ -843,6 +878,7 @@ Godot MCP Native 实现了 **154 个工具**，分为 6 大类（含核心和补
 | 参数 | 类型 | 必需 | 描述 |
 |------|------|------|------|
 | `scene_path` | string | 是 | 场景文件路径 |
+| `allow_ui_focus` | boolean | 否 | 免打扰模式下允许本次调用切换当前编辑器场景（默认 `false`） |
 
 **返回值**：
 | 字段 | 类型 | 描述 |
@@ -904,6 +940,27 @@ Godot MCP Native 实现了 **154 个工具**，分为 6 大类（含核心和补
 
 ---
 
+### close_scene_tab
+
+关闭当前场景标签页，或先激活指定场景标签页再关闭。该操作会改变编辑器场景标签状态，在 `vibe_coding_mode=true` 时需要本次调用传入 `allow_ui_focus=true`。
+
+**参数**：
+| 参数 | 类型 | 必需 | 描述 |
+|------|------|------|------|
+| `scene_path` | string | 否 | 要关闭的场景路径。如不提供，关闭当前活动场景 |
+| `allow_ui_focus` | boolean | 否 | 免打扰模式下允许本次调用激活或关闭场景标签（默认 `false`） |
+
+**返回值**：
+| 字段 | 类型 | 描述 |
+|------|------|------|
+| `status` | string | `"success"` |
+| `closed_scene` | string | 被关闭的场景路径 |
+| `remaining_count` | int | 关闭后仍打开的场景数量 |
+
+**注解**：`readOnlyHint=false`, `destructiveHint=true`, `idempotentHint=false`
+
+---
+
 ### 31. list_project_scenes
 
 列出项目中的所有场景文件。
@@ -951,6 +1008,7 @@ Godot MCP Native 实现了 **154 个工具**，分为 6 大类（含核心和补
 | 参数 | 类型 | 必需 | 描述 |
 |------|------|------|------|
 | `scene_path` | string | 否 | 指定要运行的场景路径。如不提供，运行主场景 |
+| `allow_window` | boolean | 否 | 免打扰模式下允许本次调用打开运行窗口（默认 `false`） |
 
 **返回值**：
 | 字段 | 类型 | 描述 |
@@ -966,7 +1024,10 @@ Godot MCP Native 实现了 **154 个工具**，分为 6 大类（含核心和补
 
 停止运行项目（Stop 按钮）。
 
-**参数**：无
+**参数**：
+| 参数 | 类型 | 必需 | 描述 |
+|------|------|------|------|
+| `allow_window` | boolean | 否 | 免打扰模式下允许本次调用控制运行窗口（默认 `false`） |
 
 **返回值**：
 | 字段 | 类型 | 描述 |
@@ -1012,6 +1073,49 @@ Godot MCP Native 实现了 **154 个工具**，分为 6 大类（含核心和补
 ```
 
 **注解**：`readOnlyHint=true`, `destructiveHint=false`, `idempotentHint=true`
+
+---
+
+### select_node
+
+在当前编辑场景中选择节点，并在 Inspector 中编辑该节点。该操作会改变编辑器选择和焦点，在 `vibe_coding_mode=true` 时需要本次调用传入 `allow_ui_focus=true`。
+
+**参数**：
+| 参数 | 类型 | 必需 | 描述 |
+|------|------|------|------|
+| `node_path` | string | 是 | 节点路径（如 `/root/MainScene/Player`） |
+| `clear_existing` | boolean | 否 | 选择前是否清空现有选择（默认 `true`） |
+| `allow_ui_focus` | boolean | 否 | 免打扰模式下允许本次调用改变编辑器选择/焦点（默认 `false`） |
+
+**返回值**：
+| 字段 | 类型 | 描述 |
+|------|------|------|
+| `status` | string | `"success"` |
+| `node_path` | string | 被选择节点的友好路径 |
+| `node_type` | string | 节点类型 |
+| `selected_count` | int | 选择后的节点数量 |
+
+**注解**：`readOnlyHint=false`, `destructiveHint=false`, `idempotentHint=true`
+
+---
+
+### select_file
+
+在 Godot FileSystem dock 中选择项目文件。该操作会改变编辑器文件选择，在 `vibe_coding_mode=true` 时需要本次调用传入 `allow_ui_focus=true`。
+
+**参数**：
+| 参数 | 类型 | 必需 | 描述 |
+|------|------|------|------|
+| `file_path` | string | 是 | 项目文件路径（如 `res://scenes/Main.tscn`） |
+| `allow_ui_focus` | boolean | 否 | 免打扰模式下允许本次调用改变 FileSystem 选择（默认 `false`） |
+
+**返回值**：
+| 字段 | 类型 | 描述 |
+|------|------|------|
+| `status` | string | `"success"` |
+| `file_path` | string | 被选择的文件路径 |
+
+**注解**：`readOnlyHint=false`, `destructiveHint=false`, `idempotentHint=true`
 
 ---
 

--- a/test/quiet_mode_static_check.py
+++ b/test/quiet_mode_static_check.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+import re
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+CHECKS = [
+    (
+        "addons/godot_mcp/tools/editor_tools_native.gd",
+        {
+            "_tool_run_project": ["play_custom_scene", "play_current_scene", "play_main_scene"],
+            "_tool_stop_project": ["stop_playing_scene"],
+            "_tool_select_node": ["edit_node"],
+            "_tool_select_file": ["select_file"],
+        },
+        "VIBE_CODING_POLICY.evaluate_",
+    ),
+    (
+        "addons/godot_mcp/tools/scene_tools_native.gd",
+        {
+            "_tool_open_scene": ["open_scene_from_path"],
+            "_tool_close_scene_tab": ["open_scene_from_path", "close_scene"],
+        },
+        "VIBE_CODING_POLICY.evaluate_editor_focus",
+    ),
+    (
+        "addons/godot_mcp/tools/script_tools_native.gd",
+        {
+            "_tool_open_script_at_line": ["edit_script"],
+        },
+        "VIBE_CODING_POLICY.should_grab_focus",
+    ),
+]
+
+
+def extract_function(text: str, name: str) -> str:
+    match = re.search(rf"^func {re.escape(name)}\b.*?(?=^func |\Z)", text, re.M | re.S)
+    if not match:
+        raise AssertionError(f"Missing function {name}")
+    return match.group(0)
+
+
+def main() -> int:
+    failures: list[str] = []
+    for relative_path, function_calls, required_guard in CHECKS:
+        path = ROOT / relative_path
+        text = path.read_text(encoding="utf-8")
+        for function_name, calls in function_calls.items():
+            try:
+                body = extract_function(text, function_name)
+            except AssertionError as exc:
+                failures.append(f"{relative_path}: {exc}")
+                continue
+            for call in calls:
+                if call not in body:
+                    failures.append(f"{relative_path}: {function_name} no longer contains expected call {call}")
+            if required_guard not in body:
+                failures.append(f"{relative_path}: {function_name} must use {required_guard}")
+
+    if failures:
+        for failure in failures:
+            print(failure, file=sys.stderr)
+        return 1
+    print("quiet_mode_static_check: all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/unit/quiet_mode_runner.gd
+++ b/test/unit/quiet_mode_runner.gd
@@ -1,0 +1,113 @@
+extends SceneTree
+
+var _failures: Array[String] = []
+
+func _init() -> void:
+	_test_policy_defaults()
+	_test_disruptive_tools_are_blocked_by_default()
+	_test_overrides_bypass_quiet_mode_gate()
+	_test_disruptive_tool_schemas_expose_overrides()
+	_test_plugin_exports_vibe_coding_mode()
+	if _failures.is_empty():
+		print("quiet_mode_runner: all checks passed")
+		quit(0)
+	else:
+		for failure in _failures:
+			printerr(failure)
+		quit(1)
+
+func _assert_true(value: bool, message: String) -> void:
+	if not value:
+		_failures.append(message)
+
+func _assert_false(value: bool, message: String) -> void:
+	if value:
+		_failures.append(message)
+
+func _assert_eq(actual: Variant, expected: Variant, message: String) -> void:
+	if actual != expected:
+		_failures.append("%s expected=%s actual=%s" % [message, str(expected), str(actual)])
+
+func _assert_blocked(result: Dictionary, tool_name: String) -> void:
+	_assert_true(bool(result.get("blocked", false)), tool_name + " should be blocked in Vibe Coding mode")
+	_assert_eq(str(result.get("reason", "")), "vibe_coding_mode", tool_name + " should report vibe_coding_mode")
+	_assert_true(str(result.get("error", "")).contains("Vibe Coding mode"), tool_name + " should explain the quiet-mode block")
+
+func _assert_not_quiet_block(result: Dictionary, tool_name: String) -> void:
+	_assert_false(bool(result.get("blocked", false)), tool_name + " override should bypass quiet-mode block")
+	_assert_false(str(result.get("reason", "")) == "vibe_coding_mode", tool_name + " override should not report vibe_coding_mode")
+
+func _assert_tool_schema_has_property(server_core: MCPServerCore, tool_name: String, property_name: String) -> void:
+	_assert_true(server_core.has_tool(tool_name), tool_name + " should be registered")
+	if not server_core.has_tool(tool_name):
+		return
+	var tool: MCPTypes.MCPTool = server_core.get_tool(tool_name)
+	var input_schema: Dictionary = tool.input_schema
+	var properties: Dictionary = input_schema.get("properties", {})
+	_assert_true(properties.has(property_name), tool_name + " schema should expose " + property_name)
+
+func _test_policy_defaults() -> void:
+	var policy: GDScript = load("res://addons/godot_mcp/utils/vibe_coding_policy.gd")
+	_assert_blocked(policy.evaluate_editor_focus(true, {}), "policy editor focus")
+	_assert_blocked(policy.evaluate_runtime_window(true, {}), "policy runtime window")
+	_assert_not_quiet_block(policy.evaluate_editor_focus(true, {"allow_ui_focus": true}), "policy editor focus")
+	_assert_not_quiet_block(policy.evaluate_runtime_window(true, {"allow_window": true}), "policy runtime window")
+	_assert_false(policy.should_grab_focus(true, {}), "script focus should be disabled by quiet mode")
+	_assert_true(policy.should_grab_focus(true, {"allow_ui_focus": true, "grab_focus": true}), "allow_ui_focus should preserve requested script focus")
+	_assert_true(policy.should_grab_focus(false, {"grab_focus": true}), "normal mode should preserve requested script focus")
+
+func _test_disruptive_tools_are_blocked_by_default() -> void:
+	var editor_tools: RefCounted = load("res://addons/godot_mcp/tools/editor_tools_native.gd").new()
+	_assert_blocked(editor_tools._tool_run_project({}), "run_project")
+	_assert_blocked(editor_tools._tool_stop_project({}), "stop_project")
+	_assert_blocked(editor_tools._tool_select_node({"node_path": "/root/Main"}), "select_node")
+	_assert_blocked(editor_tools._tool_select_file({"file_path": "res://project.godot"}), "select_file")
+
+	var scene_tools: RefCounted = load("res://addons/godot_mcp/tools/scene_tools_native.gd").new()
+	_assert_blocked(scene_tools._tool_open_scene({"scene_path": "res://TestScene.tscn"}), "open_scene")
+	_assert_blocked(scene_tools._tool_close_scene_tab({}), "close_scene_tab")
+
+func _test_overrides_bypass_quiet_mode_gate() -> void:
+	var editor_tools: RefCounted = load("res://addons/godot_mcp/tools/editor_tools_native.gd").new()
+	_assert_not_quiet_block(editor_tools._tool_run_project({"allow_window": true}), "run_project")
+	_assert_not_quiet_block(editor_tools._tool_stop_project({"allow_window": true}), "stop_project")
+	_assert_not_quiet_block(editor_tools._tool_select_node({"node_path": "/root/Main", "allow_ui_focus": true}), "select_node")
+	_assert_not_quiet_block(editor_tools._tool_select_file({"file_path": "res://project.godot", "allow_ui_focus": true}), "select_file")
+
+	var scene_tools: RefCounted = load("res://addons/godot_mcp/tools/scene_tools_native.gd").new()
+	_assert_not_quiet_block(scene_tools._tool_open_scene({"scene_path": "res://TestScene.tscn", "allow_ui_focus": true}), "open_scene")
+	_assert_not_quiet_block(scene_tools._tool_close_scene_tab({"allow_ui_focus": true}), "close_scene_tab")
+
+func _test_disruptive_tool_schemas_expose_overrides() -> void:
+	var editor_capture: MCPServerCore = MCPServerCore.new()
+	var editor_tools: RefCounted = load("res://addons/godot_mcp/tools/editor_tools_native.gd").new()
+	editor_tools._register_get_editor_state(editor_capture)
+	editor_tools._register_run_project(editor_capture)
+	editor_tools._register_stop_project(editor_capture)
+	editor_tools._register_select_node(editor_capture)
+	editor_tools._register_select_file(editor_capture)
+	var editor_state_tool: MCPTypes.MCPTool = editor_capture.get_tool("get_editor_state")
+	_assert_false(editor_state_tool.input_schema.get("properties", {}).has("allow_window"), "get_editor_state should remain read-only and not expose allow_window")
+	_assert_tool_schema_has_property(editor_capture, "run_project", "allow_window")
+	_assert_tool_schema_has_property(editor_capture, "stop_project", "allow_window")
+	_assert_tool_schema_has_property(editor_capture, "select_node", "allow_ui_focus")
+	_assert_tool_schema_has_property(editor_capture, "select_file", "allow_ui_focus")
+
+	var scene_capture: MCPServerCore = MCPServerCore.new()
+	var scene_tools: RefCounted = load("res://addons/godot_mcp/tools/scene_tools_native.gd").new()
+	scene_tools._register_open_scene(scene_capture)
+	scene_tools._register_close_scene_tab(scene_capture)
+	_assert_tool_schema_has_property(scene_capture, "open_scene", "allow_ui_focus")
+	_assert_tool_schema_has_property(scene_capture, "close_scene_tab", "allow_ui_focus")
+
+	var script_capture: MCPServerCore = MCPServerCore.new()
+	var script_tools: RefCounted = load("res://addons/godot_mcp/tools/script_tools_native.gd").new()
+	script_tools._register_open_script_at_line(script_capture)
+	_assert_tool_schema_has_property(script_capture, "open_script_at_line", "allow_ui_focus")
+
+func _test_plugin_exports_vibe_coding_mode() -> void:
+	var plugin_script: GDScript = load("res://addons/godot_mcp/mcp_server_native.gd")
+	var property_names: Array[String] = []
+	for property in plugin_script.get_script_property_list():
+		property_names.append(str(property.get("name", "")))
+	_assert_true(property_names.has("vibe_coding_mode"), "plugin should export vibe_coding_mode")

--- a/test/unit/quiet_mode_runner.gd.uid
+++ b/test/unit/quiet_mode_runner.gd.uid
@@ -1,0 +1,1 @@
+uid://ti525dn0jnob

--- a/test/unit/test_mcp_server_native.gd
+++ b/test/unit/test_mcp_server_native.gd
@@ -92,6 +92,7 @@ func test_export_variables():
 	assert_true(prop_names.has("http_port"), "Should have http_port export")
 	assert_true(prop_names.has("auth_enabled"), "Should have auth_enabled export")
 	assert_true(prop_names.has("log_level"), "Should have log_level export")
+	assert_true(prop_names.has("vibe_coding_mode"), "Should have vibe_coding_mode export")
 
 func test_has_load_tool_states_in_enter_tree():
 	var methods: Array = _plugin_script.get_script_method_list()

--- a/test/unit/test_vibe_coding_policy.gd
+++ b/test/unit/test_vibe_coding_policy.gd
@@ -1,0 +1,27 @@
+extends "res://addons/gut/test.gd"
+
+var _policy_script: GDScript = null
+
+func before_each():
+	_policy_script = load("res://addons/godot_mcp/utils/vibe_coding_policy.gd")
+
+func after_each():
+	_policy_script = null
+
+func test_quiet_mode_blocks_editor_focus_without_override():
+	var result: Dictionary = _policy_script.evaluate_editor_focus(true, {})
+	assert_true(result["blocked"], "Quiet mode should block editor focus by default")
+	assert_eq(result["reason"], "vibe_coding_mode", "Blocked result should identify vibe coding mode")
+
+func test_editor_focus_override_allows_focus():
+	var result: Dictionary = _policy_script.evaluate_editor_focus(true, {"allow_ui_focus": true})
+	assert_false(result["blocked"], "Explicit allow_ui_focus should bypass quiet mode")
+
+func test_quiet_mode_forces_script_open_without_focus():
+	assert_false(_policy_script.should_grab_focus(true, {}), "Quiet mode should not grab script editor focus")
+	assert_true(_policy_script.should_grab_focus(false, {"grab_focus": true}), "Normal mode should preserve requested focus")
+
+func test_quiet_mode_blocks_runtime_window_without_override():
+	var result: Dictionary = _policy_script.evaluate_runtime_window(true, {})
+	assert_true(result["blocked"], "Quiet mode should block project run windows by default")
+	assert_false(_policy_script.evaluate_runtime_window(true, {"allow_window": true})["blocked"], "Explicit allow_window should bypass quiet mode")

--- a/test/unit/test_vibe_coding_policy.gd.uid
+++ b/test/unit/test_vibe_coding_policy.gd.uid
@@ -1,0 +1,1 @@
+uid://dvi864eb12wmp


### PR DESCRIPTION
## Summary

- Rebase the PR branch onto the latest `upstream/main` so GitHub can merge it cleanly.
- Add default-on Vibe Coding / Do Not Disturb mode so MCP can keep running in the background without stealing editor focus, changing selection/scene tabs, or opening/runtime-controlling windows unless explicitly allowed.
- Document the quiet-mode override parameters in `docs/current/tools-reference.md` while preserving upstream's current 154-tool reference.
- Add focused quiet-mode policy tests, a Godot runner, and a static guard that fails if disruptive Editor APIs are added without quiet-mode gating.

## Validation

- `python test\quiet_mode_static_check.py`
- `Godot_v4.6.2-stable_mono_win64_console.exe --headless --path C:\SourceCode\Godot-MCP-Native --script test/unit/quiet_mode_runner.gd`
- classifier/tools-reference consistency check: 154 tools
- `git diff --check`
