### PR TITLE
fix：修复 JSON-RPC id 浮点化导致 MCP 握手失败

### DIFF
--- a/addons/godot_mcp/native_mcp/mcp_types.gd
+++ b/addons/godot_mcp/native_mcp/mcp_types.gd
@@ -165,11 +165,22 @@ class MCPPrompt:
 # 工具函数
 # ============================================================================
 
+# 规范化 JSON-RPC id。
+# Godot 的 JSON 解析会把整数 id 读成 float，例如 0 -> 0.0。
+# JSON-RPC id 不应包含小数部分，部分 MCP 客户端会拒绝反序列化 0.0。
+static func normalize_jsonrpc_id(id: Variant) -> Variant:
+	if typeof(id) == TYPE_FLOAT:
+		var integer_id: int = int(id)
+		if is_equal_approx(id, float(integer_id)):
+			return integer_id
+	
+	return id
+
 # 创建标准JSON-RPC响应
 static func create_response(id: Variant, result: Variant) -> Dictionary:
 	return {
 		"jsonrpc": JSONRPC_VERSION,
-		"id": id,
+		"id": normalize_jsonrpc_id(id),
 		"result": result
 	}
 
@@ -185,7 +196,7 @@ static func create_error_response(id: Variant, code: int, message: String, data:
 	
 	return {
 		"jsonrpc": JSONRPC_VERSION,
-		"id": id,
+		"id": normalize_jsonrpc_id(id),
 		"error": error
 	}
 


### PR DESCRIPTION
## 问题

Godot 的 JSON 解析会把客户端发送的整数 JSON-RPC id 解析为浮点数，例如：

```json
{"id": 0}
```

会在服务端响应中被回传为：

```json
{"id": 0.0}
```

部分 MCP 客户端会严格校验 JSON-RPC id 类型，导致初始化握手失败，例如 Codex MCP 客户端会报：

```text
Deserialize error: data did not match any variant of untagged enum JsonRpcMessage
```

## 修复

- 新增 `MCPTypes.normalize_jsonrpc_id()`
- 在 `create_response()` 和 `create_error_response()` 中统一规范化 JSON-RPC id
- 将资源管理器中的手写 JSON-RPC 响应改为复用统一响应构造方法

该修复只会把无小数部分的 float id 转回 int，例如 `0.0 -> 0`，不会影响字符串 id、`null` id 或非整数数值。

修复 https://github.com/yurineko73/Godot-MCP-Native/issues/1

## 验证

- 已用 Codex MCP 客户端验证 initialize 握手可正常通过