### PR TITLE
fix(tools): 为输入动作事件数组补充对象项类型声明

### DIFF
--- a/addons/godot_mcp/tools/debug_tools_native.gd
+++ b/addons/godot_mcp/tools/debug_tools_native.gd
@@ -1976,7 +1976,7 @@ func _register_upsert_runtime_input_action(server_core: RefCounted) -> void:
 				"action_name": {"type": "string"},
 				"deadzone": {"type": "number", "default": 0.5},
 				"erase_existing": {"type": "boolean", "default": false},
-				"events": {"type": "array", "description": "Optional structured input event payloads to add to the action."},
+				"events": {"type": "array", "items": {"type": "object"}, "description": "Optional structured input event payloads to add to the action."},
 				"session_id": {"type": "integer"},
 				"timeout_ms": {"type": "integer", "default": 1500}
 			},

--- a/addons/godot_mcp/tools/project_tools_native.gd
+++ b/addons/godot_mcp/tools/project_tools_native.gd
@@ -238,7 +238,7 @@ func _register_upsert_project_input_action(server_core: RefCounted) -> void:
 			"action_name": {"type": "string"},
 			"deadzone": {"type": "number", "default": 0.5},
 			"erase_existing": {"type": "boolean", "default": false},
-			"events": {"type": "array", "description": "Optional structured input event payloads to store on the action."}
+			"events": {"type": "array", "items": {"type": "object"}, "description": "Optional structured input event payloads to store on the action."}
 		},
 		"required": ["action_name"]
 	}


### PR DESCRIPTION
修复Failed to validate tool mcp_godot-naitve_upsert_runtime_input_action: Error: tool parameters array type must have items. Please open an issue for the MCP server or extension which provides this tool问题