### PR TITLE
fix(readme): correct MCP server URL port from 19080 to 9080

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ npm install mcp-remote
       "command": "npx",
       "args": [
         "mcp-remote",
-        "http://localhost:19080/mcp"
+        "http://localhost:9080/mcp"
       ]
     }
   }
@@ -141,7 +141,7 @@ With authentication:
 
 [mcp_servers.godot-mcp]
 type = "streamableHttp"
-url = "http://localhost:19080/mcp"
+url = "http://localhost:9080/mcp"
 ```
 
 ## 💬 Example Prompts


### PR DESCRIPTION
Fixes a small README error: the default MCP server port was incorrect for some configurations. This updates it from `19080` to `9080`.