### PR TITLE
fix: bound gdmcp collection commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ dist/
 Thumbs.db
 
 # Build artifacts
+cli/gdmcp/target/
 *.o
 *.os
 *.obj

--- a/cli/gdmcp/README.md
+++ b/cli/gdmcp/README.md
@@ -53,11 +53,33 @@ gdmcp --json tools schema get_runtime_scene_tree
 ```bash
 gdmcp --json editor state
 gdmcp --json scenes current
+gdmcp --json scenes list --limit 20
 gdmcp --json scenes tree --depth 4
+gdmcp --json nodes list --limit 20
+gdmcp --json scripts list --limit 20
 gdmcp --json scripts read res://player.gd
+gdmcp --json resources list --limit 20
+gdmcp --json project settings --filter display/
 gdmcp --json debug logs --limit 50
 gdmcp --json runtime tree --depth 4
 ```
+
+`scripts list` supports `--limit` and `--cursor` for progressive discovery. Project settings require a prefix filter because the complete settings set can be large.
+
+Batch files use raw registered tool names and object arguments:
+
+```json
+{
+  "operations": [
+    {
+      "tool": "get_project_info",
+      "arguments": {}
+    }
+  ]
+}
+```
+
+Use `batch preview` before `batch apply`; applying a batch requires `--apply`.
 
 Destructive domain commands require `--apply`:
 

--- a/cli/gdmcp/src/cli.rs
+++ b/cli/gdmcp/src/cli.rs
@@ -115,7 +115,12 @@ pub enum EditorCommand {
 #[derive(Debug, Subcommand)]
 pub enum ScenesCommand {
     Current,
-    List,
+    List {
+        #[arg(long)]
+        limit: Option<usize>,
+        #[arg(long)]
+        cursor: Option<String>,
+    },
     Tree {
         #[arg(long)]
         depth: Option<i32>,
@@ -138,6 +143,10 @@ pub enum NodesCommand {
     List {
         #[arg(long, default_value = ".")]
         parent_path: String,
+        #[arg(long)]
+        limit: Option<usize>,
+        #[arg(long)]
+        cursor: Option<String>,
     },
     Create {
         #[arg(long)]
@@ -165,7 +174,12 @@ pub enum NodesCommand {
 
 #[derive(Debug, Subcommand)]
 pub enum ScriptsCommand {
-    List,
+    List {
+        #[arg(long)]
+        limit: Option<usize>,
+        #[arg(long)]
+        cursor: Option<String>,
+    },
     Read {
         path: String,
     },
@@ -190,13 +204,18 @@ pub enum ResourcesCommand {
         resource_types: Vec<String>,
         #[arg(long)]
         limit: Option<usize>,
+        #[arg(long)]
+        cursor: Option<String>,
     },
 }
 
 #[derive(Debug, Subcommand)]
 pub enum ProjectCommand {
     Info,
-    Settings,
+    Settings {
+        #[arg(long)]
+        filter: Option<String>,
+    },
     Run,
     Stop,
 }

--- a/cli/gdmcp/src/commands/nodes.rs
+++ b/cli/gdmcp/src/commands/nodes.rs
@@ -2,7 +2,7 @@ use serde_json::{json, Value};
 
 use crate::{args::parse_value, cli::NodesCommand, client::ApiClient, error::CliError};
 
-use super::tool_call::call;
+use super::tool_call::{call, call_with_options};
 
 pub fn run(client: &ApiClient, command: NodesCommand) -> Result<Value, CliError> {
     match command {
@@ -16,13 +16,19 @@ pub fn run(client: &ApiClient, command: NodesCommand) -> Result<Value, CliError>
             None,
             None,
         ),
-        NodesCommand::List { parent_path } => call(
+        NodesCommand::List {
+            parent_path,
+            limit,
+            cursor,
+        } => call_with_options(
             client,
             "list_nodes",
             json!({"parent_path": parent_path}),
             false,
             false,
             None,
+            limit,
+            cursor,
             None,
             None,
         ),

--- a/cli/gdmcp/src/commands/project.rs
+++ b/cli/gdmcp/src/commands/project.rs
@@ -16,16 +16,28 @@ pub fn run(client: &ApiClient, command: ProjectCommand) -> Result<Value, CliErro
             None,
             None,
         ),
-        ProjectCommand::Settings => call(
-            client,
-            "get_project_settings",
-            json!({}),
-            false,
-            false,
-            None,
-            None,
-            None,
-        ),
+        ProjectCommand::Settings { filter } => {
+            let filter = filter.ok_or_else(|| {
+                CliError::InvalidArguments(
+                    "project settings requires --filter <prefix> because the full settings set can be large".to_string(),
+                )
+            })?;
+            if filter.trim().is_empty() {
+                return Err(CliError::InvalidArguments(
+                    "project settings requires a non-empty --filter <prefix>".to_string(),
+                ));
+            }
+            call(
+                client,
+                "get_project_settings",
+                json!({"filter": filter}),
+                false,
+                false,
+                None,
+                None,
+                None,
+            )
+        }
         ProjectCommand::Run => call(
             client,
             "run_project",

--- a/cli/gdmcp/src/commands/resources.rs
+++ b/cli/gdmcp/src/commands/resources.rs
@@ -2,7 +2,7 @@ use serde_json::{json, Value};
 
 use crate::{cli::ResourcesCommand, client::ApiClient, error::CliError};
 
-use super::tool_call::call;
+use super::tool_call::call_with_options;
 
 pub fn run(client: &ApiClient, command: ResourcesCommand) -> Result<Value, CliError> {
     match command {
@@ -10,12 +10,13 @@ pub fn run(client: &ApiClient, command: ResourcesCommand) -> Result<Value, CliEr
             search_path,
             resource_types,
             limit,
+            cursor,
         } => {
             let arguments = json!({
                 "search_path": search_path,
                 "resource_types": resource_types,
             });
-            call(
+            call_with_options(
                 client,
                 "list_project_resources",
                 arguments,
@@ -23,6 +24,8 @@ pub fn run(client: &ApiClient, command: ResourcesCommand) -> Result<Value, CliEr
                 false,
                 None,
                 limit,
+                cursor,
+                None,
                 None,
             )
         }

--- a/cli/gdmcp/src/commands/scenes.rs
+++ b/cli/gdmcp/src/commands/scenes.rs
@@ -2,7 +2,7 @@ use serde_json::{json, Value};
 
 use crate::{cli::ScenesCommand, client::ApiClient, error::CliError};
 
-use super::tool_call::call;
+use super::tool_call::{call, call_with_options};
 
 pub fn run(client: &ApiClient, command: ScenesCommand) -> Result<Value, CliError> {
     match command {
@@ -16,13 +16,15 @@ pub fn run(client: &ApiClient, command: ScenesCommand) -> Result<Value, CliError
             None,
             None,
         ),
-        ScenesCommand::List => call(
+        ScenesCommand::List { limit, cursor } => call_with_options(
             client,
             "list_project_scenes",
             json!({"search_path": "res://"}),
             false,
             false,
             None,
+            limit,
+            cursor,
             None,
             None,
         ),

--- a/cli/gdmcp/src/commands/scripts.rs
+++ b/cli/gdmcp/src/commands/scripts.rs
@@ -4,17 +4,19 @@ use serde_json::{json, Value};
 
 use crate::{cli::ScriptsCommand, client::ApiClient, error::CliError};
 
-use super::tool_call::call;
+use super::tool_call::{call, call_with_options};
 
 pub fn run(client: &ApiClient, command: ScriptsCommand) -> Result<Value, CliError> {
     match command {
-        ScriptsCommand::List => call(
+        ScriptsCommand::List { limit, cursor } => call_with_options(
             client,
             "list_project_scripts",
             json!({"search_path": "res://"}),
             false,
             false,
             None,
+            limit,
+            cursor,
             None,
             None,
         ),

--- a/cli/gdmcp/src/commands/tool_call.rs
+++ b/cli/gdmcp/src/commands/tool_call.rs
@@ -40,6 +40,33 @@ pub fn call(
     limit: Option<usize>,
     depth: Option<i32>,
 ) -> Result<Value, CliError> {
+    call_with_options(
+        client,
+        name,
+        arguments,
+        apply,
+        allow_open_world,
+        fields,
+        limit,
+        None,
+        depth,
+        None,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn call_with_options(
+    client: &ApiClient,
+    name: &str,
+    arguments: Value,
+    apply: bool,
+    allow_open_world: bool,
+    fields: Option<Vec<String>>,
+    limit: Option<usize>,
+    cursor: Option<String>,
+    depth: Option<i32>,
+    max_bytes: Option<usize>,
+) -> Result<Value, CliError> {
     client.post(
         &format!("/cli/v1/tools/{name}/execute"),
         &ExecuteRequest {
@@ -49,9 +76,9 @@ pub fn call(
             allow_open_world,
             fields,
             limit,
-            cursor: None,
+            cursor,
             depth,
-            max_bytes: None,
+            max_bytes,
         },
     )
 }

--- a/cli/gdmcp/tests/cli_parser.rs
+++ b/cli/gdmcp/tests/cli_parser.rs
@@ -28,3 +28,116 @@ fn tool_call_rejects_two_argument_sources() {
         .assert()
         .failure();
 }
+
+#[test]
+fn scripts_list_accepts_limit_and_cursor() {
+    let mut command = Command::cargo_bin("gdmcp").unwrap();
+    command
+        .args([
+            "--json",
+            "--url",
+            "http://127.0.0.1:1",
+            "--timeout",
+            "1",
+            "scripts",
+            "list",
+            "--limit",
+            "5",
+            "--cursor",
+            "10",
+        ])
+        .assert()
+        .code(4);
+}
+
+#[test]
+fn project_settings_requires_a_filter() {
+    let mut command = Command::cargo_bin("gdmcp").unwrap();
+    command
+        .args(["--json", "project", "settings"])
+        .assert()
+        .code(2)
+        .stdout(predicate::str::contains("--filter"));
+}
+
+#[test]
+fn project_settings_accepts_a_filter() {
+    let mut command = Command::cargo_bin("gdmcp").unwrap();
+    command
+        .args([
+            "--json",
+            "--url",
+            "http://127.0.0.1:1",
+            "--timeout",
+            "1",
+            "project",
+            "settings",
+            "--filter",
+            "display/",
+        ])
+        .assert()
+        .code(4);
+}
+
+#[test]
+fn scenes_list_accepts_limit_and_cursor() {
+    let mut command = Command::cargo_bin("gdmcp").unwrap();
+    command
+        .args([
+            "--json",
+            "--url",
+            "http://127.0.0.1:1",
+            "--timeout",
+            "1",
+            "scenes",
+            "list",
+            "--limit",
+            "5",
+            "--cursor",
+            "10",
+        ])
+        .assert()
+        .code(4);
+}
+
+#[test]
+fn nodes_list_accepts_limit_and_cursor() {
+    let mut command = Command::cargo_bin("gdmcp").unwrap();
+    command
+        .args([
+            "--json",
+            "--url",
+            "http://127.0.0.1:1",
+            "--timeout",
+            "1",
+            "nodes",
+            "list",
+            "--limit",
+            "5",
+            "--cursor",
+            "10",
+        ])
+        .assert()
+        .code(4);
+}
+
+#[test]
+fn resources_list_accepts_a_cursor() {
+    let mut command = Command::cargo_bin("gdmcp").unwrap();
+    command
+        .args([
+            "--json",
+            "--url",
+            "http://127.0.0.1:1",
+            "--timeout",
+            "1",
+            "resources",
+            "list",
+            "--limit",
+            "5",
+            "--cursor",
+            "10",
+        ])
+        .assert()
+        .code(4);
+}

--- a/cli/gdmcp/tests/command_mappings.rs
+++ b/cli/gdmcp/tests/command_mappings.rs
@@ -1,5 +1,10 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
 
 #[test]
 fn destructive_node_delete_requires_apply_before_network_access() {
@@ -26,4 +31,170 @@ fn script_replace_requires_apply_before_reading_content() {
         .assert()
         .code(6)
         .stdout(predicate::str::contains("PERMISSION_REQUIRED"));
+}
+
+#[test]
+fn scripts_list_sends_limit_and_cursor_to_the_cli_api() {
+    let (url, request_rx, server_thread) = spawn_mock_server();
+    let mut command = Command::cargo_bin("gdmcp").unwrap();
+    command
+        .args([
+            "--json", "--url", &url, "scripts", "list", "--limit", "5", "--cursor", "10",
+        ])
+        .assert()
+        .success();
+
+    let request = request_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+    assert!(request.contains("/cli/v1/tools/list_project_scripts/execute"));
+    assert!(request.contains("\"limit\":5"));
+    assert!(request.contains("\"cursor\":\"10\""));
+    server_thread.join().unwrap();
+}
+
+#[test]
+fn project_settings_sends_the_filter_to_the_cli_api() {
+    let (url, request_rx, server_thread) = spawn_mock_server();
+    let mut command = Command::cargo_bin("gdmcp").unwrap();
+    command
+        .args([
+            "--json", "--url", &url, "project", "settings", "--filter", "display/",
+        ])
+        .assert()
+        .success();
+
+    let request = request_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+    assert!(request.contains("/cli/v1/tools/get_project_settings/execute"));
+    assert!(request.contains("\"filter\":\"display/\""));
+    server_thread.join().unwrap();
+}
+
+#[test]
+fn batch_preview_uses_tool_and_arguments_operations() {
+    let (url, request_rx, server_thread) = spawn_mock_server();
+    let temp_dir = tempfile::tempdir().unwrap();
+    let batch_path = temp_dir.path().join("operations.json");
+    std::fs::write(
+        &batch_path,
+        r#"{"operations":[{"tool":"get_project_info","arguments":{}}]}"#,
+    )
+    .unwrap();
+
+    let mut command = Command::cargo_bin("gdmcp").unwrap();
+    command
+        .args(["--json", "--url", &url, "batch", "preview"])
+        .arg(&batch_path)
+        .assert()
+        .success();
+
+    let request = request_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+    assert!(request.contains("/cli/v1/tools/get_project_info/execute"));
+    assert!(request.contains("\"arguments\":{}"));
+    server_thread.join().unwrap();
+}
+
+#[test]
+fn scenes_list_sends_limit_and_cursor_to_the_cli_api() {
+    let (url, request_rx, server_thread) = spawn_mock_server();
+    let mut command = Command::cargo_bin("gdmcp").unwrap();
+    command
+        .args([
+            "--json", "--url", &url, "scenes", "list", "--limit", "5", "--cursor", "10",
+        ])
+        .assert()
+        .success();
+
+    let request = request_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+    assert!(request.contains("/cli/v1/tools/list_project_scenes/execute"));
+    assert!(request.contains("\"limit\":5"));
+    assert!(request.contains("\"cursor\":\"10\""));
+    server_thread.join().unwrap();
+}
+
+#[test]
+fn nodes_list_sends_limit_and_cursor_to_the_cli_api() {
+    let (url, request_rx, server_thread) = spawn_mock_server();
+    let mut command = Command::cargo_bin("gdmcp").unwrap();
+    command
+        .args([
+            "--json", "--url", &url, "nodes", "list", "--limit", "5", "--cursor", "10",
+        ])
+        .assert()
+        .success();
+
+    let request = request_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+    assert!(request.contains("/cli/v1/tools/list_nodes/execute"));
+    assert!(request.contains("\"limit\":5"));
+    assert!(request.contains("\"cursor\":\"10\""));
+    server_thread.join().unwrap();
+}
+
+#[test]
+fn resources_list_sends_cursor_to_the_cli_api() {
+    let (url, request_rx, server_thread) = spawn_mock_server();
+    let mut command = Command::cargo_bin("gdmcp").unwrap();
+    command
+        .args([
+            "--json",
+            "--url",
+            &url,
+            "resources",
+            "list",
+            "--limit",
+            "5",
+            "--cursor",
+            "10",
+        ])
+        .assert()
+        .success();
+
+    let request = request_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+    assert!(request.contains("/cli/v1/tools/list_project_resources/execute"));
+    assert!(request.contains("\"limit\":5"));
+    assert!(request.contains("\"cursor\":\"10\""));
+    server_thread.join().unwrap();
+}
+
+fn spawn_mock_server() -> (String, mpsc::Receiver<String>, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let (request_tx, request_rx) = mpsc::channel();
+    let server_thread = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut request = Vec::new();
+        let mut buffer = [0_u8; 4096];
+        loop {
+            let bytes_read = stream.read(&mut buffer).unwrap();
+            if bytes_read == 0 {
+                break;
+            }
+            request.extend_from_slice(&buffer[..bytes_read]);
+            if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                let headers_end = request
+                    .windows(4)
+                    .position(|window| window == b"\r\n\r\n")
+                    .unwrap();
+                let headers = String::from_utf8_lossy(&request[..headers_end]);
+                let content_length = headers
+                    .lines()
+                    .find_map(|line| line.strip_prefix("Content-Length: "))
+                    .and_then(|value| value.trim().parse::<usize>().ok())
+                    .unwrap_or(0);
+                if request.len() >= headers_end + 4 + content_length {
+                    break;
+                }
+            }
+        }
+        request_tx
+            .send(String::from_utf8_lossy(&request).into_owned())
+            .unwrap();
+
+        let body = r#"{"schema_version":1,"ok":true,"data":{},"meta":{"truncated":false,"next_cursor":null}}"#;
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        stream.write_all(response.as_bytes()).unwrap();
+    });
+    (format!("http://{address}"), request_rx, server_thread)
 }

--- a/docs/current/gdmcp-cli-reference.md
+++ b/docs/current/gdmcp-cli-reference.md
@@ -47,6 +47,39 @@ Supported output controls are `--fields`, `--limit`, `--cursor`, `--depth`, `--m
 
 The first release includes commands for editor state, scenes, nodes, scripts, project operations, logs, runtime inspection, and batch preview/apply.
 
+Use bounds when listing project content:
+
+```powershell
+gdmcp --json scenes list --limit 20
+gdmcp --json nodes list --limit 20
+gdmcp --json scripts list --limit 20
+gdmcp --json scripts list --limit 20 --cursor 20
+gdmcp --json resources list --limit 20 --cursor 20
+```
+
+Project settings can be large, so the high-level command requires a prefix filter:
+
+```powershell
+gdmcp --json project settings --filter display/
+```
+
+Do not request the complete settings set without a filter. Use `tools schema get_project_settings` and a raw call only when a different filter is required.
+
+Batch files use registered tool names and object arguments:
+
+```json
+{
+  "operations": [
+    {
+      "tool": "get_project_info",
+      "arguments": {}
+    }
+  ]
+}
+```
+
+Run `batch preview` before `batch apply`; `batch apply` still requires `--apply`.
+
 ## Safety
 
 The server derives policy from MCP annotations and category metadata:

--- a/docs/superpowers/specs/2026-07-24-gdmcp-agent-cli-design.md
+++ b/docs/superpowers/specs/2026-07-24-gdmcp-agent-cli-design.md
@@ -572,7 +572,7 @@ gdmcp nodes resolve|get|create|delete|move|rename
 gdmcp nodes properties set
 gdmcp scripts list|resolve|read|create|replace|validate
 gdmcp resources list|resolve|get|create
-gdmcp project info|run|stop
+gdmcp project info|settings|run|stop
 gdmcp debug logs|clear
 gdmcp runtime info|tree
 gdmcp runtime nodes get|set|call
@@ -668,6 +668,7 @@ The first release implements the commands that cover the most common workflows.
 | `scripts validate` | `validate_script` |
 | `resources list` | `list_project_resources` |
 | `project info` | `get_project_info` |
+| `project settings --filter <prefix>` | `get_project_settings` with `filter` |
 | `project run` | `run_project` |
 | `project stop` | `stop_project` |
 | `debug logs` | `get_editor_logs` |
@@ -688,16 +689,16 @@ Batch input:
 {
   "operations": [
     {
-      "command": "nodes.properties.set",
-      "target": "/root/Main/Player",
-      "property": "speed",
-      "value": 300
+      "tool": "get_project_info",
+      "arguments": {}
     }
   ]
 }
 ```
 
-`batch preview` validates every operation, resolves mappings, checks policy, and returns the calls that would be made without invoking write handlers.
+The first release uses raw registered tool names and JSON object arguments in batch files. It does not accept high-level domain command objects such as `command`, `target`, or `property`; use a domain command directly for one high-level operation, or resolve the underlying tool first with `tools schema`.
+
+`batch preview` validates every operation, checks tool policy, and returns the calls that would be made without invoking write handlers.
 
 `batch apply` requires `--apply`, executes operations sequentially, and stops at the first failure by default. A later `--continue-on-error` option is not part of the first release.
 

--- a/skills/gdmcp/SKILL.md
+++ b/skills/gdmcp/SKILL.md
@@ -18,8 +18,13 @@ Prefer narrow domain commands for common operations:
 
 ```bash
 gdmcp --json scenes current
+gdmcp --json scenes list --limit 20
 gdmcp --json scenes tree --depth 4
+gdmcp --json nodes list --limit 20
+gdmcp --json scripts list --limit 20
 gdmcp --json scripts read res://player.gd
+gdmcp --json resources list --limit 20
+gdmcp --json project settings --filter display/
 gdmcp --json debug logs --limit 50
 gdmcp --json runtime tree --depth 4
 ```
@@ -38,10 +43,26 @@ Rules:
 - Prefer domain commands over raw `tool-call`.
 - Do not request the complete catalog with full schemas.
 - Bound output with `--limit`, `--depth`, `--fields`, `--max-bytes`, or `--out`.
+- Use `scripts list --limit <n> [--cursor <cursor>]` for progressive script discovery.
+- Bound `scenes list`, `nodes list`, and `resources list` with `--limit`; use `--cursor` when continuing a result set.
+- Always pass `project settings --filter <prefix>`; the unfiltered settings set can be too large.
 - Use `batch preview` before `batch apply`.
+- Batch files use registered tool names and object arguments, for example:
+
+  ```json
+  {
+    "operations": [
+      {
+        "tool": "get_project_info",
+        "arguments": {}
+      }
+    ]
+  }
+  ```
 - Destructive domain commands require `--apply`.
 - Raw destructive calls require `--apply` after reviewing the selected tool schema.
 - Runtime and other open-world raw calls require `--allow-open-world`.
 - Never print or request the bearer token. Configure it through `GODOT_MCP_TOKEN` or another environment variable selected with `--token-env`.
+- Use only output options shown by a command's `--help`; not every command supports every generic output option.
 
 See `references/command-workflows.md` for copyable task flows.


### PR DESCRIPTION
## Summary

- Bound every high-volume collection command with `--limit` and `--cursor` where applicable.
- Require `project settings --filter <prefix>` so large settings responses fail locally with an actionable error.
- Align batch documentation and the Companion Skill with the implemented `tool` + `arguments` input format.
- Add regression coverage for CLI parsing and CLI API request mappings.
- Ignore the Rust CLI release target directory.

## Root cause

The initial CLI implementation exposed output bounds for raw `tool-call` and some domain commands, but several collection wrappers did not forward pagination controls. `project settings` also discarded the underlying tool's existing filter parameter and requested the full settings set unconditionally. The authoritative design and user-facing guidance were updated to describe the actual supported batch contract.

## Validation

- `cargo fmt --manifest-path cli/gdmcp/Cargo.toml --check`
- `cargo clippy --manifest-path cli/gdmcp/Cargo.toml --all-targets --locked -- -D warnings`
- `cargo test --manifest-path cli/gdmcp/Cargo.toml --locked` — 19 Rust tests, 0 failures
- Windows release package: `dist/gdmcp-0.1.0-x86_64-pc-windows-msvc.zip`
- SHA-256 installation verification from the release archive
- Live Windows smoke tests against the running Godot MCP service: `doctor`, scene/node/resource/script pagination, filtered project settings, batch preview, and the unfiltered-settings guard

Linux and macOS shell flows remain documented as unverified, consistent with the project validation policy.
