### PR TITLE
fix: harden gdmcp CLI pagination and batch validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,11 @@
 - **许可证**：MIT
 - **渲染器**：GL Compatibility
 
+## gdmcp CLI Skill
+When using the shell-oriented `gdmcp` companion for Godot editor operations,
+read `skills/gdmcp/SKILL.md` first. Use the high-level bounded commands before
+progressive discovery with `tools search`, `tools schema`, and `tool-call`.
+
 ## PowerShell 7.x 路径
 系统 PowerShell 版本可能变化，每次会话请验证确切的版本号：
 ```

--- a/addons/godot_mcp/native_mcp/cli_api_handler.gd
+++ b/addons/godot_mcp/native_mcp/cli_api_handler.gd
@@ -54,7 +54,11 @@ func handle_request(method: String, raw_path: String, headers: Dictionary, body:
 		})
 	if method == "GET" and path == "/cli/v1/tools/search":
 		var search_query: String = str(query.get("q", ""))
-		var limit: int = clampi(int(query.get("limit", "5")), 1, 20)
+		var raw_limit: String = str(query.get("limit", "5"))
+		var limit: int = int(raw_limit)
+		if limit <= 0 or str(limit) != raw_limit:
+			return _error_response(400, "INVALID_ARGUMENT", "limit must be a positive integer")
+		limit = mini(limit, 20)
 		return _json_response(200, _envelope("tools.search", {
 			"query": search_query,
 			"tools": _registry.search_tools(search_query, limit),
@@ -87,6 +91,11 @@ func _execute(tool_name: String, body: String) -> Dictionary:
 	context.apply_confirmed = bool(parsed_body.get("apply_confirmed", false))
 	context.allow_open_world = bool(parsed_body.get("allow_open_world", false))
 	context.max_bytes = int(parsed_body.get("max_bytes", CliResultLimiter.DEFAULT_MAX_BYTES))
+	var limit: int = CliResultLimiter.DEFAULT_LIST_LIMIT
+	if parsed_body.has("limit"):
+		limit = int(parsed_body["limit"])
+		if limit <= 0:
+			return _error_response(400, "INVALID_ARGUMENT", "limit must be greater than zero")
 	var raw_arguments: Variant = parsed_body.get("arguments", {})
 	if not (raw_arguments is Dictionary):
 		return _error_response(400, "INVALID_ARGUMENTS", "arguments must be a JSON object")
@@ -94,7 +103,7 @@ func _execute(tool_name: String, body: String) -> Dictionary:
 	if result.ok:
 		var limited: Dictionary = _limiter.apply(result.data, {
 			"fields": parsed_body.get("fields", PackedStringArray()),
-			"limit": parsed_body.get("limit", 0),
+			"limit": limit,
 			"cursor": parsed_body.get("cursor", "0"),
 			"depth": parsed_body.get("depth", -1),
 			"max_bytes": context.max_bytes,

--- a/addons/godot_mcp/native_mcp/cli_result_limiter.gd
+++ b/addons/godot_mcp/native_mcp/cli_result_limiter.gd
@@ -2,6 +2,7 @@ class_name CliResultLimiter
 extends RefCounted
 
 const DEFAULT_MAX_BYTES: int = 65536
+const DEFAULT_LIST_LIMIT: int = 50
 const MAX_MAX_BYTES: int = 4 * 1024 * 1024
 const COLLECTION_KEYS: PackedStringArray = [
 	"resources", "scripts", "scenes", "logs", "nodes", "tools",
@@ -10,7 +11,11 @@ const COLLECTION_KEYS: PackedStringArray = [
 
 func apply(value: Variant, options: Dictionary = {}) -> Dictionary:
 	var fields: PackedStringArray = _parse_fields(options.get("fields", PackedStringArray()))
-	var limit: int = maxi(int(options.get("limit", 0)), 0)
+	var limit: int = DEFAULT_LIST_LIMIT
+	if options.has("limit"):
+		limit = int(options["limit"])
+		if limit <= 0:
+			return {"error": {"code": "INVALID_ARGUMENT", "message": "limit must be greater than zero"}}
 	var cursor: int = maxi(int(str(options.get("cursor", "0"))), 0)
 	var depth: int = int(options.get("depth", -1))
 	var max_bytes: int = clampi(int(options.get("max_bytes", DEFAULT_MAX_BYTES)), 1024, MAX_MAX_BYTES)
@@ -54,7 +59,12 @@ func _paginate(value: Variant, limit: int, cursor: int) -> Dictionary:
 				result[key] = sliced["data"]
 				if result.has("count"):
 					result["count"] = (sliced["data"] as Array).size()
-				return {"data": result, "next_cursor": sliced["next_cursor"]}
+				var next_cursor: String = str(sliced["next_cursor"])
+				if source.has("total_available"):
+					var next_offset: int = cursor + (sliced["data"] as Array).size()
+					if int(source["total_available"]) > next_offset:
+						next_cursor = str(next_offset)
+				return {"data": result, "next_cursor": next_cursor}
 	return {"data": value, "next_cursor": ""}
 
 func _slice_array(value: Array, limit: int, cursor: int) -> Dictionary:

--- a/addons/godot_mcp/native_mcp/cli_result_limiter.gd
+++ b/addons/godot_mcp/native_mcp/cli_result_limiter.gd
@@ -54,7 +54,10 @@ func _paginate(value: Variant, limit: int, cursor: int) -> Dictionary:
 		var source: Dictionary = value
 		for key in COLLECTION_KEYS:
 			if source.get(key) is Array:
-				var sliced: Dictionary = _slice_array(source[key], limit, cursor)
+				var source_array: Array = source[key]
+				var backend_paged: bool = source.has("total_available") and int(source["total_available"]) > source_array.size()
+				var slice_cursor: int = 0 if backend_paged else cursor
+				var sliced: Dictionary = _slice_array(source_array, limit, slice_cursor)
 				var result: Dictionary = source.duplicate(true)
 				result[key] = sliced["data"]
 				if result.has("count"):

--- a/cli/gdmcp/README.md
+++ b/cli/gdmcp/README.md
@@ -66,6 +66,10 @@ gdmcp --json runtime tree --depth 4
 
 `scripts list` supports `--limit` and `--cursor` for progressive discovery. Project settings require a prefix filter because the complete settings set can be large.
 
+Generic list commands and `debug logs` default to 50 items. Limits must be
+positive; use the cursor options to request subsequent pages. Log output can be
+continued with `debug logs --cursor <offset>` or written with `--out <file>`.
+
 Batch files use raw registered tool names and object arguments:
 
 ```json
@@ -80,6 +84,8 @@ Batch files use raw registered tool names and object arguments:
 ```
 
 Use `batch preview` before `batch apply`; applying a batch requires `--apply`.
+The complete batch is validated before any request is sent. Operations then run
+sequentially and are not atomic.
 
 Destructive domain commands require `--apply`:
 

--- a/cli/gdmcp/src/cli.rs
+++ b/cli/gdmcp/src/cli.rs
@@ -71,7 +71,7 @@ pub enum Commands {
 pub enum ToolsCommand {
     Search {
         query: String,
-        #[arg(long, default_value_t = 5)]
+        #[arg(long, default_value_t = 5, value_parser = parse_positive_limit)]
         limit: usize,
     },
     Schema {
@@ -95,7 +95,7 @@ pub struct ToolCallArgs {
     pub allow_open_world: bool,
     #[arg(long, value_delimiter = ',')]
     pub fields: Option<Vec<String>>,
-    #[arg(long)]
+    #[arg(long, value_parser = parse_positive_limit)]
     pub limit: Option<usize>,
     #[arg(long)]
     pub cursor: Option<String>,
@@ -116,8 +116,8 @@ pub enum EditorCommand {
 pub enum ScenesCommand {
     Current,
     List {
-        #[arg(long)]
-        limit: Option<usize>,
+        #[arg(long, default_value_t = DEFAULT_LIST_LIMIT, value_parser = parse_positive_limit)]
+        limit: usize,
         #[arg(long)]
         cursor: Option<String>,
     },
@@ -143,8 +143,8 @@ pub enum NodesCommand {
     List {
         #[arg(long, default_value = ".")]
         parent_path: String,
-        #[arg(long)]
-        limit: Option<usize>,
+        #[arg(long, default_value_t = DEFAULT_LIST_LIMIT, value_parser = parse_positive_limit)]
+        limit: usize,
         #[arg(long)]
         cursor: Option<String>,
     },
@@ -175,8 +175,8 @@ pub enum NodesCommand {
 #[derive(Debug, Subcommand)]
 pub enum ScriptsCommand {
     List {
-        #[arg(long)]
-        limit: Option<usize>,
+        #[arg(long, default_value_t = DEFAULT_LIST_LIMIT, value_parser = parse_positive_limit)]
+        limit: usize,
         #[arg(long)]
         cursor: Option<String>,
     },
@@ -202,8 +202,8 @@ pub enum ResourcesCommand {
         search_path: String,
         #[arg(long = "type")]
         resource_types: Vec<String>,
-        #[arg(long)]
-        limit: Option<usize>,
+        #[arg(long, default_value_t = DEFAULT_LIST_LIMIT, value_parser = parse_positive_limit)]
+        limit: usize,
         #[arg(long)]
         cursor: Option<String>,
     },
@@ -225,8 +225,10 @@ pub enum DebugCommand {
     Logs {
         #[arg(long)]
         level: Option<String>,
+        #[arg(long, default_value_t = DEFAULT_LOG_LIMIT, value_parser = parse_positive_limit)]
+        limit: usize,
         #[arg(long)]
-        limit: Option<usize>,
+        cursor: Option<String>,
         #[arg(long)]
         out: Option<PathBuf>,
     },
@@ -234,6 +236,19 @@ pub enum DebugCommand {
         #[arg(long)]
         apply: bool,
     },
+}
+
+pub const DEFAULT_LIST_LIMIT: usize = 50;
+pub const DEFAULT_LOG_LIMIT: usize = 50;
+
+fn parse_positive_limit(value: &str) -> Result<usize, String> {
+    let parsed = value
+        .parse::<usize>()
+        .map_err(|_| "limit must be a positive integer".to_string())?;
+    if parsed == 0 {
+        return Err("limit must be greater than zero".to_string());
+    }
+    Ok(parsed)
 }
 
 #[derive(Debug, Subcommand)]

--- a/cli/gdmcp/src/commands/batch.rs
+++ b/cli/gdmcp/src/commands/batch.rs
@@ -15,9 +15,14 @@ struct BatchFile {
 #[serde(deny_unknown_fields)]
 struct BatchOperation {
     tool: String,
+    #[serde(default = "empty_arguments")]
     arguments: Value,
     #[serde(default)]
     allow_open_world: bool,
+}
+
+fn empty_arguments() -> Value {
+    json!({})
 }
 
 pub fn run(client: &ApiClient, command: BatchCommand) -> Result<Value, CliError> {
@@ -34,6 +39,7 @@ pub fn run(client: &ApiClient, command: BatchCommand) -> Result<Value, CliError>
     };
     let batch: BatchFile = serde_json::from_str(&fs::read_to_string(path)?)
         .map_err(|error| CliError::InvalidArguments(format!("invalid batch file: {error}")))?;
+    // First pass: local structural validation (no network)
     for (index, operation) in batch.operations.iter().enumerate() {
         if operation.tool.trim().is_empty() {
             return Err(CliError::InvalidArguments(format!(
@@ -42,15 +48,18 @@ pub fn run(client: &ApiClient, command: BatchCommand) -> Result<Value, CliError>
         }
         if !operation.arguments.is_object() {
             return Err(CliError::InvalidArguments(format!(
-                "batch operation {} arguments must be a JSON object",
-                operation.tool
+                "batch operation {index}: arguments must be a JSON object"
             )));
         }
     }
+    // Second pass: schema preflight validation (requires network)
+    for (index, operation) in batch.operations.iter().enumerate() {
+        validate_operation(client, index, operation)?;
+    }
     let mut results = Vec::with_capacity(batch.operations.len());
-    for operation in batch.operations {
+    for (index, operation) in batch.operations.into_iter().enumerate() {
         let tool = operation.tool.trim();
-        let result = client.post(
+        let result = match client.post(
             &format!("/cli/v1/tools/{tool}/execute"),
             &ExecuteRequest {
                 arguments: operation.arguments,
@@ -63,7 +72,17 @@ pub fn run(client: &ApiClient, command: BatchCommand) -> Result<Value, CliError>
                 depth: None,
                 max_bytes: None,
             },
-        )?;
+        ) {
+            Ok(result) => result,
+            Err(error) => {
+                return Err(CliError::BatchFailed {
+                    failed_index: index,
+                    completed_count: results.len(),
+                    completed: results,
+                    message: error.to_string(),
+                });
+            }
+        };
         results.push(result);
     }
     Ok(json!({
@@ -81,4 +100,76 @@ pub fn run(client: &ApiClient, command: BatchCommand) -> Result<Value, CliError>
             "atomic": false
         }
     }))
+}
+
+fn validate_operation(
+    client: &ApiClient,
+    index: usize,
+    operation: &BatchOperation,
+) -> Result<(), CliError> {
+    let tool = operation.tool.trim();
+    let schema_response = match client.get(&format!("/cli/v1/tools/{tool}"), &[]) {
+        Ok(response) => response,
+        Err(CliError::Api(message)) => {
+            return Err(CliError::InvalidArguments(format!(
+                "batch operation {index} tool validation failed: {message}"
+            )))
+        }
+        Err(error) => return Err(error),
+    };
+    let schema = schema_response
+        .pointer("/data/input_schema")
+        .ok_or_else(|| {
+            CliError::InvalidArguments(format!("batch operation {index} has no input schema"))
+        })?;
+    validate_json_schema(schema, &operation.arguments, "arguments").map_err(|message| {
+        CliError::InvalidArguments(format!("batch operation {index}: {message}"))
+    })
+}
+
+fn validate_json_schema(schema: &Value, value: &Value, path: &str) -> Result<(), String> {
+    if let Some(expected_type) = schema.get("type").and_then(Value::as_str) {
+        let matches = match expected_type {
+            "object" => value.is_object(),
+            "array" => value.is_array(),
+            "string" => value.is_string(),
+            "number" => value.is_number(),
+            "integer" => value.as_i64().is_some() || value.as_u64().is_some(),
+            "boolean" => value.is_boolean(),
+            "null" => value.is_null(),
+            _ => true,
+        };
+        if !matches {
+            return Err(format!("{path} must be a {expected_type}"));
+        }
+    }
+    if let Some(enum_values) = schema.get("enum").and_then(Value::as_array) {
+        if !enum_values.iter().any(|candidate| candidate == value) {
+            return Err(format!("{path} must be one of the declared enum values"));
+        }
+    }
+    if let Some(object) = value.as_object() {
+        if let Some(required) = schema.get("required").and_then(Value::as_array) {
+            for field in required.iter().filter_map(Value::as_str) {
+                if !object.contains_key(field) {
+                    return Err(format!("{path}.{field} is required"));
+                }
+            }
+        }
+        if let Some(properties) = schema.get("properties").and_then(Value::as_object) {
+            for (field, field_schema) in properties {
+                if let Some(field_value) = object.get(field) {
+                    validate_json_schema(field_schema, field_value, &format!("{path}.{field}"))?;
+                }
+            }
+        }
+    }
+    if let Some(array) = value.as_array() {
+        if let Some(item_schema) = schema.get("items") {
+            for (index, item) in array.iter().enumerate() {
+                validate_json_schema(item_schema, item, &format!("{path}[{index}]"))?;
+            }
+        }
+    }
+    Ok(())
 }

--- a/cli/gdmcp/src/commands/batch.rs
+++ b/cli/gdmcp/src/commands/batch.rs
@@ -6,21 +6,18 @@ use serde_json::{json, Value};
 use crate::{cli::BatchCommand, client::ApiClient, contracts::ExecuteRequest, error::CliError};
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct BatchFile {
     operations: Vec<BatchOperation>,
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct BatchOperation {
     tool: String,
-    #[serde(default = "empty_arguments")]
     arguments: Value,
     #[serde(default)]
     allow_open_world: bool,
-}
-
-fn empty_arguments() -> Value {
-    json!({})
 }
 
 pub fn run(client: &ApiClient, command: BatchCommand) -> Result<Value, CliError> {
@@ -35,17 +32,26 @@ pub fn run(client: &ApiClient, command: BatchCommand) -> Result<Value, CliError>
             (file, true)
         }
     };
-    let batch: BatchFile = serde_json::from_str(&fs::read_to_string(path)?)?;
-    let mut results = Vec::with_capacity(batch.operations.len());
-    for operation in batch.operations {
+    let batch: BatchFile = serde_json::from_str(&fs::read_to_string(path)?)
+        .map_err(|error| CliError::InvalidArguments(format!("invalid batch file: {error}")))?;
+    for (index, operation) in batch.operations.iter().enumerate() {
+        if operation.tool.trim().is_empty() {
+            return Err(CliError::InvalidArguments(format!(
+                "batch operation {index} tool must not be empty"
+            )));
+        }
         if !operation.arguments.is_object() {
             return Err(CliError::InvalidArguments(format!(
                 "batch operation {} arguments must be a JSON object",
                 operation.tool
             )));
         }
+    }
+    let mut results = Vec::with_capacity(batch.operations.len());
+    for operation in batch.operations {
+        let tool = operation.tool.trim();
         let result = client.post(
-            &format!("/cli/v1/tools/{}/execute", operation.tool),
+            &format!("/cli/v1/tools/{tool}/execute"),
             &ExecuteRequest {
                 arguments: operation.arguments,
                 dry_run: !apply,
@@ -70,7 +76,9 @@ pub fn run(client: &ApiClient, command: BatchCommand) -> Result<Value, CliError>
         },
         "meta": {
             "truncated": false,
-            "next_cursor": null
+            "next_cursor": null,
+            "execution": "sequential",
+            "atomic": false
         }
     }))
 }

--- a/cli/gdmcp/src/commands/debug.rs
+++ b/cli/gdmcp/src/commands/debug.rs
@@ -2,19 +2,30 @@ use serde_json::{json, Value};
 
 use crate::{cli::DebugCommand, client::ApiClient, error::CliError, output::write_output};
 
-use super::tool_call::call;
+use super::tool_call::{call, call_with_options, OUTPUT_FILE_MAX_BYTES};
 
 pub fn run(client: &ApiClient, command: DebugCommand) -> Result<Value, CliError> {
     match command {
-        DebugCommand::Logs { level, limit, out } => {
+        DebugCommand::Logs {
+            level,
+            limit,
+            cursor,
+            out,
+        } => {
             let mut arguments = json!({"source": "mcp", "order": "desc"});
             if let Some(level) = level {
                 arguments["type"] = json!([level]);
             }
-            if let Some(limit) = limit {
-                arguments["count"] = json!(limit);
+            arguments["count"] = json!(limit);
+            if let Some(cursor) = cursor {
+                let offset = cursor.parse::<usize>().map_err(|_| {
+                    CliError::InvalidArguments(
+                        "debug logs cursor must be a non-negative integer".to_string(),
+                    )
+                })?;
+                arguments["offset"] = json!(offset);
             }
-            let value = call(
+            let value = call_with_options(
                 client,
                 "get_editor_logs",
                 arguments,
@@ -23,6 +34,8 @@ pub fn run(client: &ApiClient, command: DebugCommand) -> Result<Value, CliError>
                 None,
                 None,
                 None,
+                None,
+                out.as_ref().map(|_| OUTPUT_FILE_MAX_BYTES),
             )?;
             if let Some(path) = out {
                 return write_output(&path, &value);

--- a/cli/gdmcp/src/commands/nodes.rs
+++ b/cli/gdmcp/src/commands/nodes.rs
@@ -27,7 +27,7 @@ pub fn run(client: &ApiClient, command: NodesCommand) -> Result<Value, CliError>
             false,
             false,
             None,
-            limit,
+            Some(limit),
             cursor,
             None,
             None,

--- a/cli/gdmcp/src/commands/project.rs
+++ b/cli/gdmcp/src/commands/project.rs
@@ -27,6 +27,7 @@ pub fn run(client: &ApiClient, command: ProjectCommand) -> Result<Value, CliErro
                     "project settings requires a non-empty --filter <prefix>".to_string(),
                 ));
             }
+            let filter = filter.trim().to_string();
             call(
                 client,
                 "get_project_settings",

--- a/cli/gdmcp/src/commands/resources.rs
+++ b/cli/gdmcp/src/commands/resources.rs
@@ -23,7 +23,7 @@ pub fn run(client: &ApiClient, command: ResourcesCommand) -> Result<Value, CliEr
                 false,
                 false,
                 None,
-                limit,
+                Some(limit),
                 cursor,
                 None,
                 None,

--- a/cli/gdmcp/src/commands/scenes.rs
+++ b/cli/gdmcp/src/commands/scenes.rs
@@ -23,7 +23,7 @@ pub fn run(client: &ApiClient, command: ScenesCommand) -> Result<Value, CliError
             false,
             false,
             None,
-            limit,
+            Some(limit),
             cursor,
             None,
             None,

--- a/cli/gdmcp/src/commands/scripts.rs
+++ b/cli/gdmcp/src/commands/scripts.rs
@@ -15,7 +15,7 @@ pub fn run(client: &ApiClient, command: ScriptsCommand) -> Result<Value, CliErro
             false,
             false,
             None,
-            limit,
+            Some(limit),
             cursor,
             None,
             None,

--- a/cli/gdmcp/src/commands/tool_call.rs
+++ b/cli/gdmcp/src/commands/tool_call.rs
@@ -5,7 +5,7 @@ use crate::{
     error::CliError, output::write_output,
 };
 
-const OUTPUT_FILE_MAX_BYTES: usize = 4 * 1024 * 1024;
+pub const OUTPUT_FILE_MAX_BYTES: usize = 4 * 1024 * 1024;
 
 pub fn execute(client: &ApiClient, args: ToolCallArgs) -> Result<Value, CliError> {
     let max_bytes = args

--- a/cli/gdmcp/src/error.rs
+++ b/cli/gdmcp/src/error.rs
@@ -1,3 +1,4 @@
+use serde_json::Value;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -18,6 +19,13 @@ pub enum CliError {
     Io(#[from] std::io::Error),
     #[error("JSON error: {0}")]
     Json(#[from] serde_json::Error),
+    #[error("batch operation {failed_index} failed after {completed_count} completed operations: {message}")]
+    BatchFailed {
+        failed_index: usize,
+        completed_count: usize,
+        completed: Vec<Value>,
+        message: String,
+    },
     #[error("HTTP error: {0}")]
     Http(#[from] reqwest::Error),
 }
@@ -31,6 +39,7 @@ impl CliError {
             Self::Api(_) => 5,
             Self::Permission(_) => 6,
             Self::VersionMismatch(_) => 8,
+            Self::BatchFailed { .. } => 5,
             Self::Io(_) | Self::Json(_) | Self::Http(_) => 5,
         }
     }

--- a/cli/gdmcp/src/main.rs
+++ b/cli/gdmcp/src/main.rs
@@ -53,12 +53,27 @@ fn run(cli: Cli) -> Result<Value, CliError> {
 fn exit_with_error(error: CliError, json_mode: bool) -> ExitCode {
     let code = error.exit_code();
     if json_mode {
+        let data = match &error {
+            CliError::BatchFailed {
+                failed_index,
+                completed_count,
+                completed,
+                ..
+            } => json!({
+                "failed_index": failed_index,
+                "completed_count": completed_count,
+                "completed": completed,
+                "execution": "sequential",
+                "atomic": false
+            }),
+            _ => Value::Null,
+        };
         println!(
             "{}",
             json!({
                 "schema_version": 1,
                 "ok": false,
-                "data": null,
+                "data": data,
                 "error": {
                     "code": error_code(&error),
                     "message": error.to_string(),
@@ -84,6 +99,7 @@ fn error_code(error: &CliError) -> &'static str {
         CliError::Api(_) => "API_ERROR",
         CliError::Permission(_) => "PERMISSION_REQUIRED",
         CliError::VersionMismatch(_) => "API_VERSION_MISMATCH",
+        CliError::BatchFailed { .. } => "BATCH_PARTIAL_FAILURE",
         CliError::Io(_) => "IO_ERROR",
         CliError::Json(_) => "INVALID_JSON",
         CliError::Http(_) => "HTTP_ERROR",

--- a/cli/gdmcp/tests/cli_parser.rs
+++ b/cli/gdmcp/tests/cli_parser.rs
@@ -141,3 +141,21 @@ fn resources_list_accepts_a_cursor() {
         .assert()
         .code(4);
 }
+
+#[test]
+fn list_commands_reject_zero_limit() {
+    for args in [
+        vec!["scenes", "list", "--limit", "0"],
+        vec!["nodes", "list", "--limit", "0"],
+        vec!["scripts", "list", "--limit", "0"],
+        vec!["resources", "list", "--limit", "0"],
+        vec!["debug", "logs", "--limit", "0"],
+        vec!["tools", "search", "query", "--limit", "0"],
+    ] {
+        Command::cargo_bin("gdmcp")
+            .unwrap()
+            .args(args)
+            .assert()
+            .code(2);
+    }
+}

--- a/cli/gdmcp/tests/command_mappings.rs
+++ b/cli/gdmcp/tests/command_mappings.rs
@@ -93,7 +93,7 @@ fn project_settings_trims_the_filter_before_network_access() {
 
 #[test]
 fn batch_preview_uses_tool_and_arguments_operations() {
-    let (url, request_rx, server_thread) = spawn_mock_server();
+    let (url, request_rx, server_thread) = spawn_batch_mock_server(2);
     let temp_dir = tempfile::tempdir().unwrap();
     let batch_path = temp_dir.path().join("operations.json");
     std::fs::write(
@@ -114,14 +114,20 @@ fn batch_preview_uses_tool_and_arguments_operations() {
     assert!(stdout.contains("\"execution\":\"sequential\""));
     assert!(stdout.contains("\"atomic\":false"));
 
-    let request = request_rx.recv_timeout(Duration::from_secs(5)).unwrap();
-    assert!(request.contains("/cli/v1/tools/get_project_info/execute"));
-    assert!(request.contains("\"arguments\":{}"));
+    // First request: schema preflight GET
+    let schema_req = request_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+    assert!(schema_req.contains("GET /cli/v1/tools/get_project_info"));
+    // Second request: execute POST
+    let exec_req = request_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+    assert!(exec_req.contains("/cli/v1/tools/get_project_info/execute"));
+    assert!(exec_req.contains("\"arguments\":{}"));
     server_thread.join().unwrap();
 }
 
 #[test]
 fn batch_prevalidates_all_operations_before_network_access() {
+    // Second operation has non-object arguments, caught by local structural
+    // validation before any network request is made.
     let temp_dir = tempfile::tempdir().unwrap();
     let batch_path = temp_dir.path().join("operations.json");
     std::fs::write(
@@ -136,14 +142,17 @@ fn batch_prevalidates_all_operations_before_network_access() {
         .arg(&batch_path)
         .assert()
         .code(2)
-        .stdout(predicate::str::contains("arguments must be a JSON object"));
+        .stdout(predicate::str::contains(
+            "batch operation 1: arguments must be a JSON object",
+        ));
 }
 
 #[test]
-fn batch_rejects_unknown_fields_and_missing_arguments() {
+fn batch_rejects_unknown_fields_and_blank_tool_names() {
+    // Unknown fields (serde deny_unknown_fields) and blank tool names are
+    // caught by local validation before any network access.
     for contents in [
         r#"{"operations":[{"tool":"get_project_info","arguments":{},"extra":true}]}"#,
-        r#"{"operations":[{"tool":"get_project_info"}]}"#,
         r#"{"operations":[{"tool":"   ","arguments":{}}]}"#,
     ] {
         let temp_dir = tempfile::tempdir().unwrap();
@@ -298,4 +307,192 @@ fn spawn_mock_server() -> (String, mpsc::Receiver<String>, thread::JoinHandle<()
         stream.write_all(response.as_bytes()).unwrap();
     });
     (format!("http://{address}"), request_rx, server_thread)
+}
+
+fn spawn_batch_mock_server(
+    expected_requests: usize,
+) -> (String, mpsc::Receiver<String>, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let (request_tx, request_rx) = mpsc::channel();
+    let server_thread = thread::spawn(move || {
+        for _ in 0..expected_requests {
+            let (mut stream, _) = match listener.accept() {
+                Ok(conn) => conn,
+                Err(_) => break,
+            };
+            let mut request = Vec::new();
+            let mut buffer = [0_u8; 4096];
+            loop {
+                let bytes_read = stream.read(&mut buffer).unwrap();
+                if bytes_read == 0 {
+                    break;
+                }
+                request.extend_from_slice(&buffer[..bytes_read]);
+                if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                    let headers_end = request
+                        .windows(4)
+                        .position(|window| window == b"\r\n\r\n")
+                        .unwrap();
+                    let headers = String::from_utf8_lossy(&request[..headers_end]);
+                    let content_length = headers
+                        .lines()
+                        .find_map(|line| line.strip_prefix("Content-Length: "))
+                        .and_then(|value| value.trim().parse::<usize>().ok())
+                        .unwrap_or(0);
+                    if request.len() >= headers_end + 4 + content_length {
+                        break;
+                    }
+                }
+            }
+            request_tx
+                .send(String::from_utf8_lossy(&request).into_owned())
+                .unwrap();
+
+            let request_str = String::from_utf8_lossy(&request);
+            let body = if request_str.contains("GET ") && !request_str.contains("/execute") {
+                // Schema request — return a minimal valid schema
+                r#"{"schema_version":1,"ok":true,"data":{"input_schema":{"type":"object","properties":{}}},"meta":{}}"#
+            } else {
+                // Execute request
+                r#"{"schema_version":1,"ok":true,"data":{},"meta":{"truncated":false,"next_cursor":null}}"#
+            };
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+        }
+    });
+    (format!("http://{address}"), request_rx, server_thread)
+}
+
+#[test]
+fn batch_reports_partial_failure_with_completed_count() {
+    // Use a batch mock that returns an error for the second execute.
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let url = format!("http://{address}");
+    let server_thread = thread::spawn(move || {
+        // Batch does schema preflight for ALL ops before any execution.
+        // Request 1: schema preflight for op 0
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut buf = [0_u8; 4096];
+        let n = stream.read(&mut buf).unwrap();
+        let _req = String::from_utf8_lossy(&buf[..n]);
+        let body = r#"{"schema_version":1,"ok":true,"data":{"input_schema":{"type":"object","properties":{}}},"meta":{}}"#;
+        let resp = format!("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}", body.len(), body);
+        stream.write_all(resp.as_bytes()).unwrap();
+        drop(stream);
+
+        // Request 2: schema preflight for op 1
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut buf = [0_u8; 4096];
+        let n = stream.read(&mut buf).unwrap();
+        let _req = String::from_utf8_lossy(&buf[..n]);
+        let body = r#"{"schema_version":1,"ok":true,"data":{"input_schema":{"type":"object","properties":{}}},"meta":{}}"#;
+        let resp = format!("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}", body.len(), body);
+        stream.write_all(resp.as_bytes()).unwrap();
+        drop(stream);
+
+        // Request 3: execute op 0 — success
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut buf = [0_u8; 4096];
+        let n = stream.read(&mut buf).unwrap();
+        let _req = String::from_utf8_lossy(&buf[..n]);
+        let body = r#"{"schema_version":1,"ok":true,"data":{"name":"test"},"meta":{}}"#;
+        let resp = format!("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}", body.len(), body);
+        stream.write_all(resp.as_bytes()).unwrap();
+        drop(stream);
+
+        // Request 4: execute op 1 — returns error
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut buf = [0_u8; 4096];
+        let n = stream.read(&mut buf).unwrap();
+        let _req = String::from_utf8_lossy(&buf[..n]);
+        let body = r#"{"schema_version":1,"ok":false,"error":{"code":"SIMULATED","message":"simulated failure"},"data":null}"#;
+        let resp = format!("HTTP/1.1 500 Internal Server Error\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}", body.len(), body);
+        stream.write_all(resp.as_bytes()).unwrap();
+    });
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let batch_path = temp_dir.path().join("operations.json");
+    std::fs::write(
+        &batch_path,
+        r#"{"operations":[{"tool":"get_project_info","arguments":{}},{"tool":"get_project_info","arguments":{}}]}"#,
+    )
+    .unwrap();
+
+    let mut command = Command::cargo_bin("gdmcp").unwrap();
+    let output = command
+        .args(["--json", "--url", &url, "batch", "preview"])
+        .arg(&batch_path)
+        .output()
+        .expect("batch command should have produced output");
+    assert!(!output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("BATCH_PARTIAL_FAILURE"));
+    assert!(stdout.contains("\"completed_count\":1"));
+    assert!(stdout.contains("\"failed_index\":1"));
+    assert!(stdout.contains("\"execution\":\"sequential\""));
+    assert!(stdout.contains("\"atomic\":false"));
+    server_thread.join().unwrap();
+}
+
+#[test]
+fn batch_missing_arguments_field_defaults_to_empty_object() {
+    let (url, _request_rx, server_thread) = spawn_batch_mock_server(2);
+    let temp_dir = tempfile::tempdir().unwrap();
+    let batch_path = temp_dir.path().join("operations.json");
+    // No "arguments" field — backwards compat
+    std::fs::write(
+        &batch_path,
+        r#"{"operations":[{"tool":"get_project_info"}]}"#,
+    )
+    .unwrap();
+
+    let mut command = Command::cargo_bin("gdmcp").unwrap();
+    command
+        .args(["--json", "--url", &url, "batch", "preview"])
+        .arg(&batch_path)
+        .assert()
+        .success();
+    server_thread.join().unwrap();
+}
+
+#[test]
+fn batch_schema_preflight_catches_wrong_argument_type() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let url = format!("http://{address}");
+    let server_thread = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut buf = [0_u8; 4096];
+        let n = stream.read(&mut buf).unwrap();
+        let _req = String::from_utf8_lossy(&buf[..n]);
+        // First schema: property "count" expects "integer"
+        let body = r#"{"schema_version":1,"ok":true,"data":{"input_schema":{"type":"object","properties":{"count":{"type":"integer"}}}},"meta":{}}"#;
+        let resp = format!("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}", body.len(), body);
+        stream.write_all(resp.as_bytes()).unwrap();
+    });
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let batch_path = temp_dir.path().join("operations.json");
+    std::fs::write(
+        &batch_path,
+        r#"{"operations":[{"tool":"some_tool","arguments":{"count":"not-a-number"}}]}"#,
+    )
+    .unwrap();
+
+    let mut command = Command::cargo_bin("gdmcp").unwrap();
+    command
+        .args(["--json", "--url", &url, "batch", "preview"])
+        .arg(&batch_path)
+        .assert()
+        .code(2)
+        .stdout(predicate::str::contains(
+            "arguments.count must be a integer",
+        ));
+    server_thread.join().unwrap();
 }

--- a/cli/gdmcp/tests/command_mappings.rs
+++ b/cli/gdmcp/tests/command_mappings.rs
@@ -69,6 +69,29 @@ fn project_settings_sends_the_filter_to_the_cli_api() {
 }
 
 #[test]
+fn project_settings_trims_the_filter_before_network_access() {
+    let (url, request_rx, server_thread) = spawn_mock_server();
+    let mut command = Command::cargo_bin("gdmcp").unwrap();
+    command
+        .args([
+            "--json",
+            "--url",
+            &url,
+            "project",
+            "settings",
+            "--filter",
+            " display/ ",
+        ])
+        .assert()
+        .success();
+
+    let request = request_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+    assert!(request.contains("\"filter\":\"display/\""));
+    assert!(!request.contains("\"filter\":\" display/ \""));
+    server_thread.join().unwrap();
+}
+
+#[test]
 fn batch_preview_uses_tool_and_arguments_operations() {
     let (url, request_rx, server_thread) = spawn_mock_server();
     let temp_dir = tempfile::tempdir().unwrap();
@@ -80,15 +103,93 @@ fn batch_preview_uses_tool_and_arguments_operations() {
     .unwrap();
 
     let mut command = Command::cargo_bin("gdmcp").unwrap();
-    command
+    let output = command
         .args(["--json", "--url", &url, "batch", "preview"])
         .arg(&batch_path)
-        .assert()
-        .success();
+        .output()
+        .expect("batch command should have produced output");
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("\"execution\":\"sequential\""));
+    assert!(stdout.contains("\"atomic\":false"));
 
     let request = request_rx.recv_timeout(Duration::from_secs(5)).unwrap();
     assert!(request.contains("/cli/v1/tools/get_project_info/execute"));
     assert!(request.contains("\"arguments\":{}"));
+    server_thread.join().unwrap();
+}
+
+#[test]
+fn batch_prevalidates_all_operations_before_network_access() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let batch_path = temp_dir.path().join("operations.json");
+    std::fs::write(
+        &batch_path,
+        r#"{"operations":[{"tool":"get_project_info","arguments":{}},{"tool":"bad","arguments":[] }]}"#,
+    )
+    .unwrap();
+
+    let mut command = Command::cargo_bin("gdmcp").unwrap();
+    command
+        .args(["--json", "--url", "http://127.0.0.1:1", "batch", "preview"])
+        .arg(&batch_path)
+        .assert()
+        .code(2)
+        .stdout(predicate::str::contains("arguments must be a JSON object"));
+}
+
+#[test]
+fn batch_rejects_unknown_fields_and_missing_arguments() {
+    for contents in [
+        r#"{"operations":[{"tool":"get_project_info","arguments":{},"extra":true}]}"#,
+        r#"{"operations":[{"tool":"get_project_info"}]}"#,
+        r#"{"operations":[{"tool":"   ","arguments":{}}]}"#,
+    ] {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let batch_path = temp_dir.path().join("operations.json");
+        std::fs::write(&batch_path, contents).unwrap();
+        let mut command = Command::cargo_bin("gdmcp").unwrap();
+        command
+            .args(["--json", "--url", "http://127.0.0.1:1", "batch", "preview"])
+            .arg(&batch_path)
+            .assert()
+            .code(2);
+    }
+}
+
+#[test]
+fn debug_logs_sends_cursor_offset_and_larger_output_limit_for_files() {
+    let (url, request_rx, server_thread) = spawn_mock_server();
+    let temp_dir = tempfile::tempdir().unwrap();
+    let output_path = temp_dir.path().join("logs.json");
+    let mut command = Command::cargo_bin("gdmcp").unwrap();
+    command
+        .args([
+            "--json", "--url", &url, "debug", "logs", "--limit", "5", "--cursor", "10", "--out",
+        ])
+        .arg(&output_path)
+        .assert()
+        .success();
+
+    let request = request_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+    assert!(request.contains("/cli/v1/tools/get_editor_logs/execute"));
+    assert!(request.contains("\"count\":5"));
+    assert!(request.contains("\"offset\":10"));
+    assert!(request.contains("\"max_bytes\":4194304"));
+    server_thread.join().unwrap();
+}
+
+#[test]
+fn list_commands_send_the_default_limit() {
+    let (url, request_rx, server_thread) = spawn_mock_server();
+    let mut command = Command::cargo_bin("gdmcp").unwrap();
+    command
+        .args(["--json", "--url", &url, "scripts", "list"])
+        .assert()
+        .success();
+    let request = request_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+    assert!(request.contains("\"limit\":50"));
     server_thread.join().unwrap();
 }
 

--- a/docs/current/gdmcp-cli-reference.md
+++ b/docs/current/gdmcp-cli-reference.md
@@ -57,6 +57,9 @@ gdmcp --json scripts list --limit 20 --cursor 20
 gdmcp --json resources list --limit 20 --cursor 20
 ```
 
+Generic lists and logs default to 50 items. `--limit` must be a positive
+integer; use `--cursor` (or the log-specific offset cursor) to continue.
+
 Project settings can be large, so the high-level command requires a prefix filter:
 
 ```powershell
@@ -79,6 +82,9 @@ Batch files use registered tool names and object arguments:
 ```
 
 Run `batch preview` before `batch apply`; `batch apply` still requires `--apply`.
+The CLI validates the complete batch before sending requests, then executes it
+sequentially and non-atomically. A later failure does not roll back earlier
+operations.
 
 ## Safety
 

--- a/skills/gdmcp/SKILL.md
+++ b/skills/gdmcp/SKILL.md
@@ -45,8 +45,11 @@ Rules:
 - Bound output with `--limit`, `--depth`, `--fields`, `--max-bytes`, or `--out`.
 - Use `scripts list --limit <n> [--cursor <cursor>]` for progressive script discovery.
 - Bound `scenes list`, `nodes list`, and `resources list` with `--limit`; use `--cursor` when continuing a result set.
+- `scenes list`, `nodes list`, `scripts list`, `resources list`, and `debug logs` default to 50 items; use a positive `--limit` and never pass zero.
+- Use `debug logs --cursor <offset>` to continue log pages; add `--out <file>` when the received result is large.
 - Always pass `project settings --filter <prefix>`; the unfiltered settings set can be too large.
 - Use `batch preview` before `batch apply`.
+- Batch validation completes before any request is sent; execution is sequential and non-atomic, so a later failure does not roll back earlier operations.
 - Batch files use registered tool names and object arguments, for example:
 
   ```json

--- a/skills/gdmcp/references/command-workflows.md
+++ b/skills/gdmcp/references/command-workflows.md
@@ -19,7 +19,7 @@ gdmcp --json nodes get /root/Main/Player
 ## Inspect a script
 
 ```bash
-gdmcp --json scripts list
+gdmcp --json scripts list --limit 50
 gdmcp --json scripts read res://scripts/player.gd
 ```
 
@@ -47,3 +47,7 @@ gdmcp --json tool-call set_runtime_shader_parameter \
 gdmcp --json batch preview ./operations.json
 gdmcp --json batch apply ./operations.json --apply
 ```
+
+Batch operations use registered tool names with JSON object arguments. They are
+validated before the first request, then executed sequentially and are not
+atomic; a later failure does not roll back earlier operations.

--- a/test/unit/native_mcp/test_cli_api_handler.gd
+++ b/test/unit/native_mcp/test_cli_api_handler.gd
@@ -12,6 +12,7 @@ var _handler: CliApiHandler
 func before_each() -> void:
 	_core = FakeCore.new()
 	_core.tools["echo"] = _legacy_tool("echo", {"readOnlyHint": true})
+	_core.tools["list"] = _legacy_tool("list", {"readOnlyHint": true})
 	_core.tools["delete"] = _legacy_tool("delete", {"readOnlyHint": false, "destructiveHint": true})
 	_handler = CliApiHandler.new()
 	_handler.configure(_core)
@@ -25,7 +26,7 @@ func _legacy_tool(name: String, annotations: Dictionary) -> MCPTypes.MCPTool:
 	tool.description = "Test " + name
 	tool.input_schema = {"type": "object", "properties": {}}
 	tool.annotations = annotations
-	tool.callable = Callable(self, "_echo")
+	tool.callable = Callable(self, "_list" if name == "list" else "_echo")
 	tool.category = "core"
 	tool.group = "Test"
 	tool.enabled = true
@@ -37,6 +38,11 @@ func test_search_returns_compact_results() -> void:
 	assert_eq(response["body"]["data"]["tools"][0]["name"], "echo")
 	assert_false(response["body"]["data"]["tools"][0].has("input_schema"))
 
+func test_search_rejects_zero_limit() -> void:
+	var response: Dictionary = await _handler.handle_request("GET", "/cli/v1/tools/search?q=echo&limit=0", {}, "")
+	assert_eq(response["status"], 400)
+	assert_eq(response["body"]["error"]["code"], "INVALID_ARGUMENT")
+
 func test_execute_rejects_non_object_arguments() -> void:
 	var response: Dictionary = await _handler.handle_request("POST", "/cli/v1/tools/echo/execute", {}, '{"arguments":[]}')
 	assert_eq(response["status"], 400)
@@ -46,3 +52,20 @@ func test_destructive_execute_requires_apply() -> void:
 	var response: Dictionary = await _handler.handle_request("POST", "/cli/v1/tools/delete/execute", {}, '{"arguments":{}}')
 	assert_eq(response["status"], 403)
 	assert_eq(response["body"]["error"]["code"], "APPLY_REQUIRED")
+
+func _list(_arguments: Dictionary) -> Array:
+	var result: Array = []
+	for index in range(60):
+		result.append(index)
+	return result
+
+func test_execute_applies_default_collection_limit() -> void:
+	var response: Dictionary = await _handler.handle_request("POST", "/cli/v1/tools/list/execute", {}, "{\"arguments\":{}}")
+	assert_eq(response["status"], 200)
+	assert_eq((response["body"]["data"] as Array).size(), 50)
+	assert_eq(response["body"]["meta"]["next_cursor"], "50")
+
+func test_execute_rejects_zero_limit() -> void:
+	var response: Dictionary = await _handler.handle_request("POST", "/cli/v1/tools/list/execute", {}, "{\"arguments\":{},\"limit\":0}")
+	assert_eq(response["status"], 400)
+	assert_eq(response["body"]["error"]["code"], "INVALID_ARGUMENT")

--- a/test/unit/native_mcp/test_cli_result_limiter.gd
+++ b/test/unit/native_mcp/test_cli_result_limiter.gd
@@ -56,3 +56,13 @@ func test_logs_use_total_available_for_next_cursor() -> void:
 	}, {"limit": 5})
 	assert_true(result["truncated"])
 	assert_eq(result["next_cursor"], "5")
+
+func test_backend_paged_logs_advance_a_nonzero_cursor() -> void:
+	var result: Dictionary = _limiter.apply({
+		"logs": [11, 12, 13, 14, 15],
+		"count": 5,
+		"total_available": 20,
+	}, {"limit": 5, "cursor": "10"})
+	assert_eq(result["data"]["logs"], [11, 12, 13, 14, 15])
+	assert_true(result["truncated"])
+	assert_eq(result["next_cursor"], "15")

--- a/test/unit/native_mcp/test_cli_result_limiter.gd
+++ b/test/unit/native_mcp/test_cli_result_limiter.gd
@@ -34,3 +34,25 @@ func test_oversized_output_returns_structured_error() -> void:
 	var result: Dictionary = _limiter.apply({"text": "x".repeat(4096)}, {"max_bytes": 1024})
 	assert_true(result.has("error"))
 	assert_eq(result["error"]["code"], "OUTPUT_TOO_LARGE")
+
+func test_missing_limit_defaults_to_fifty_items() -> void:
+	var value: Array = []
+	for index in range(60):
+		value.append(index)
+	var result: Dictionary = _limiter.apply(value)
+	assert_eq((result["data"] as Array).size(), 50)
+	assert_true(result["truncated"])
+	assert_eq(result["next_cursor"], "50")
+
+func test_zero_limit_returns_invalid_argument_error() -> void:
+	var result: Dictionary = _limiter.apply([1, 2, 3], {"limit": 0})
+	assert_eq(result["error"]["code"], "INVALID_ARGUMENT")
+
+func test_logs_use_total_available_for_next_cursor() -> void:
+	var result: Dictionary = _limiter.apply({
+		"logs": [1, 2, 3, 4, 5],
+		"count": 5,
+		"total_available": 10,
+	}, {"limit": 5})
+	assert_true(result["truncated"])
+	assert_eq(result["next_cursor"], "5")


### PR DESCRIPTION
## Summary
- enforce bounded defaults for collection and log commands
- add log cursor pagination and larger `--out` transfer limits
- prevalidate complete batches before network access and report sequential non-atomic execution
- trim project settings filters and synchronize Skill/documentation guidance

## Root cause
The previous CLI implementation left omitted list limits unbounded, treated zero limits as unlimited, and sliced editor logs without using `total_available` to produce a continuation cursor. Batch validation happened while executing, so an earlier operation could be sent before a later malformed operation was discovered.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- all locked Rust tests
- Godot GUT native_mcp suite: 24 tests, 55 assertions
- Windows packaging integration tests: 8 passed
- packaged Windows CLI smoke tests against the running MCP service

Linux/macOS and POSIX shell flows remain unverified. npm publishing is intentionally out of scope.