### PR TITLE
feat: align CLI commands with design spec — lines, fields, subcommands

### DIFF
--- a/cli/gdmcp/src/cli.rs
+++ b/cli/gdmcp/src/cli.rs
@@ -21,6 +21,43 @@ pub struct Cli {
     pub command: Commands,
 }
 
+/// Parsed line range for `scripts read --lines`.
+#[derive(Debug, Clone)]
+pub struct LineRange {
+    pub start: usize,
+    pub end: Option<usize>,
+}
+
+impl std::str::FromStr for LineRange {
+    type Err = String;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let (start_str, end_str) = value.split_once(':').ok_or_else(|| {
+            "line range must be start:end or start: (e.g. 1:200 or 50:)".to_string()
+        })?;
+        let start = start_str
+            .parse::<usize>()
+            .map_err(|_| format!("invalid start line: {start_str}"))?;
+        if start == 0 {
+            return Err("start line must be greater than zero".to_string());
+        }
+        let end = if end_str.is_empty() {
+            None
+        } else {
+            Some(
+                end_str
+                    .parse::<usize>()
+                    .map_err(|_| format!("invalid end line: {end_str}"))?,
+            )
+        };
+        if let Some(end) = end {
+            if end < start {
+                return Err(format!("end line {end} is before start line {start}"));
+            }
+        }
+        Ok(LineRange { start, end })
+    }
+}
+
 #[derive(Debug, Subcommand)]
 pub enum Commands {
     Doctor,
@@ -139,6 +176,8 @@ pub enum ScenesCommand {
 pub enum NodesCommand {
     Get {
         node_path: String,
+        #[arg(long, value_delimiter = ',')]
+        fields: Option<Vec<String>>,
     },
     List {
         #[arg(long, default_value = ".")]
@@ -156,6 +195,17 @@ pub enum NodesCommand {
         #[arg(long)]
         name: String,
     },
+    #[command(subcommand)]
+    Properties(NodesPropertiesCommand),
+    Delete {
+        node_path: String,
+        #[arg(long)]
+        apply: bool,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum NodesPropertiesCommand {
     Set {
         node_path: String,
         #[arg(long)]
@@ -164,11 +214,6 @@ pub enum NodesCommand {
         value: String,
         #[arg(long)]
         value_json: bool,
-    },
-    Delete {
-        node_path: String,
-        #[arg(long)]
-        apply: bool,
     },
 }
 
@@ -182,6 +227,8 @@ pub enum ScriptsCommand {
     },
     Read {
         path: String,
+        #[arg(long, value_parser = parse_line_range)]
+        lines: Option<LineRange>,
     },
     Validate {
         path: String,
@@ -251,6 +298,10 @@ fn parse_positive_limit(value: &str) -> Result<usize, String> {
     Ok(parsed)
 }
 
+fn parse_line_range(value: &str) -> Result<LineRange, String> {
+    value.parse()
+}
+
 #[derive(Debug, Subcommand)]
 pub enum RuntimeCommand {
     Info,
@@ -260,9 +311,8 @@ pub enum RuntimeCommand {
         #[arg(long, value_delimiter = ',')]
         fields: Option<Vec<String>>,
     },
-    Node {
-        node_path: String,
-    },
+    #[command(subcommand)]
+    Nodes(RuntimeNodesCommand),
     Screenshot {
         #[arg(long, default_value = "user://mcp_runtime_capture.jpg")]
         save_path: String,
@@ -270,6 +320,29 @@ pub enum RuntimeCommand {
         format: String,
         #[arg(long)]
         viewport_path: Option<String>,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum RuntimeNodesCommand {
+    Get {
+        node_path: String,
+    },
+    Set {
+        node_path: String,
+        #[arg(long)]
+        property: String,
+        #[arg(long)]
+        value: String,
+        #[arg(long)]
+        value_json: bool,
+    },
+    Call {
+        node_path: String,
+        #[arg(long)]
+        method: String,
+        #[arg(long)]
+        arguments: Option<String>,
     },
 }
 

--- a/cli/gdmcp/src/commands/nodes.rs
+++ b/cli/gdmcp/src/commands/nodes.rs
@@ -1,21 +1,32 @@
 use serde_json::{json, Value};
 
-use crate::{args::parse_value, cli::NodesCommand, client::ApiClient, error::CliError};
+use crate::{
+    args::parse_value,
+    cli::{NodesCommand, NodesPropertiesCommand},
+    client::ApiClient,
+    error::CliError,
+};
 
 use super::tool_call::{call, call_with_options};
 
 pub fn run(client: &ApiClient, command: NodesCommand) -> Result<Value, CliError> {
     match command {
-        NodesCommand::Get { node_path } => call(
-            client,
-            "get_node_properties",
-            json!({"node_path": node_path}),
-            false,
-            false,
-            None,
-            None,
-            None,
-        ),
+        NodesCommand::Get { node_path, fields } => {
+            let mut value = call(
+                client,
+                "get_node_properties",
+                json!({"node_path": node_path}),
+                false,
+                false,
+                None,
+                None,
+                None,
+            )?;
+            if let Some(field_names) = fields {
+                filter_node_properties(&mut value, &field_names);
+            }
+            Ok(value)
+        }
         NodesCommand::List {
             parent_path,
             limit,
@@ -50,25 +61,27 @@ pub fn run(client: &ApiClient, command: NodesCommand) -> Result<Value, CliError>
             None,
             None,
         ),
-        NodesCommand::Set {
-            node_path,
-            property,
-            value,
-            value_json,
-        } => call(
-            client,
-            "update_node_property",
-            json!({
-                "node_path": node_path,
-                "property_name": property,
-                "property_value": parse_value(value, value_json)?
-            }),
-            false,
-            false,
-            None,
-            None,
-            None,
-        ),
+        NodesCommand::Properties(props) => match props {
+            NodesPropertiesCommand::Set {
+                node_path,
+                property,
+                value,
+                value_json,
+            } => call(
+                client,
+                "update_node_property",
+                json!({
+                    "node_path": node_path,
+                    "property_name": property,
+                    "property_value": parse_value(value, value_json)?
+                }),
+                false,
+                false,
+                None,
+                None,
+                None,
+            ),
+        },
         NodesCommand::Delete { node_path, apply } => {
             require_apply(apply, "nodes delete")?;
             call(
@@ -81,6 +94,15 @@ pub fn run(client: &ApiClient, command: NodesCommand) -> Result<Value, CliError>
                 None,
                 None,
             )
+        }
+    }
+}
+
+fn filter_node_properties(value: &mut Value, fields: &[String]) {
+    if let Some(props) = value.pointer_mut("/data/properties") {
+        if let Some(obj) = props.as_object_mut() {
+            let keep: Vec<String> = fields.to_vec();
+            obj.retain(|key, _| keep.contains(key));
         }
     }
 }

--- a/cli/gdmcp/src/commands/runtime.rs
+++ b/cli/gdmcp/src/commands/runtime.rs
@@ -1,6 +1,11 @@
 use serde_json::{json, Value};
 
-use crate::{cli::RuntimeCommand, client::ApiClient, error::CliError};
+use crate::{
+    args::parse_value,
+    cli::{RuntimeCommand, RuntimeNodesCommand},
+    client::ApiClient,
+    error::CliError,
+};
 
 use super::tool_call::call;
 
@@ -26,16 +31,66 @@ pub fn run(client: &ApiClient, command: RuntimeCommand) -> Result<Value, CliErro
             None,
             None,
         ),
-        RuntimeCommand::Node { node_path } => call(
-            client,
-            "inspect_runtime_node",
-            json!({"node_path": node_path}),
-            false,
-            true,
-            None,
-            None,
-            None,
-        ),
+        RuntimeCommand::Nodes(nodes) => match nodes {
+            RuntimeNodesCommand::Get { node_path } => call(
+                client,
+                "inspect_runtime_node",
+                json!({"node_path": node_path}),
+                false,
+                true,
+                None,
+                None,
+                None,
+            ),
+            RuntimeNodesCommand::Set {
+                node_path,
+                property,
+                value,
+                value_json,
+            } => call(
+                client,
+                "update_runtime_node_property",
+                json!({
+                    "node_path": node_path,
+                    "property_name": property,
+                    "property_value": parse_value(value, value_json)?
+                }),
+                false,
+                true,
+                None,
+                None,
+                None,
+            ),
+            RuntimeNodesCommand::Call {
+                node_path,
+                method,
+                arguments,
+            } => {
+                let parsed_args: Value = arguments
+                    .as_deref()
+                    .map(|s| {
+                        serde_json::from_str(s).map_err(|e| {
+                            CliError::InvalidArguments(format!("invalid JSON arguments: {e}"))
+                        })
+                    })
+                    .transpose()?
+                    .unwrap_or(Value::Array(vec![]));
+                call(
+                    client,
+                    "call_runtime_node_method",
+                    json!({
+                        "node_path": node_path,
+                        "method_name": method,
+                        "arguments": parsed_args
+                    }),
+                    false,
+                    true,
+                    None,
+                    None,
+                    None,
+                )
+            }
+        },
         RuntimeCommand::Screenshot {
             save_path,
             format,

--- a/cli/gdmcp/src/commands/scripts.rs
+++ b/cli/gdmcp/src/commands/scripts.rs
@@ -20,16 +20,22 @@ pub fn run(client: &ApiClient, command: ScriptsCommand) -> Result<Value, CliErro
             None,
             None,
         ),
-        ScriptsCommand::Read { path } => call(
-            client,
-            "read_script",
-            json!({"script_path": path}),
-            false,
-            false,
-            None,
-            None,
-            None,
-        ),
+        ScriptsCommand::Read { path, lines } => {
+            let mut value = call(
+                client,
+                "read_script",
+                json!({"script_path": path}),
+                false,
+                false,
+                None,
+                None,
+                None,
+            )?;
+            if let Some(range) = lines {
+                slice_read_script_content(&mut value, &range)?;
+            }
+            Ok(value)
+        }
         ScriptsCommand::Validate { path } => call(
             client,
             "validate_script",
@@ -61,6 +67,33 @@ pub fn run(client: &ApiClient, command: ScriptsCommand) -> Result<Value, CliErro
             )
         }
     }
+}
+
+fn slice_read_script_content(
+    value: &mut Value,
+    range: &crate::cli::LineRange,
+) -> Result<(), CliError> {
+    let content = value
+        .pointer("/data/content")
+        .and_then(Value::as_str)
+        .ok_or_else(|| CliError::Api("read_script response missing content".to_string()))?;
+    let lines: Vec<&str> = content.lines().collect();
+    let total = lines.len();
+    let start = range.start.saturating_sub(1);
+    if start >= total {
+        return Err(CliError::InvalidArguments(format!(
+            "start line {} exceeds file length of {} lines",
+            range.start, total
+        )));
+    }
+    let end = range.end.unwrap_or(total).min(total);
+    let sliced: String = lines[start..end].join("\n");
+    if let Some(data) = value.pointer_mut("/data") {
+        data["content"] = Value::String(sliced);
+        data["line_count"] = Value::Number((end - start).into());
+        data["line_offset"] = Value::Number(range.start.into());
+    }
+    Ok(())
 }
 
 fn require_apply(apply: bool, command: &str) -> Result<(), CliError> {

--- a/cli/gdmcp/tests/cli_parser.rs
+++ b/cli/gdmcp/tests/cli_parser.rs
@@ -159,3 +159,128 @@ fn list_commands_reject_zero_limit() {
             .code(2);
     }
 }
+
+#[test]
+fn scripts_read_accepts_line_range() {
+    let mut command = Command::cargo_bin("gdmcp").unwrap();
+    command
+        .args([
+            "--json",
+            "--url",
+            "http://127.0.0.1:1",
+            "--timeout",
+            "1",
+            "scripts",
+            "read",
+            "res://test.gd",
+            "--lines",
+            "10:50",
+        ])
+        .assert()
+        .code(4);
+}
+
+#[test]
+fn scripts_read_rejects_zero_start_line() {
+    Command::cargo_bin("gdmcp")
+        .unwrap()
+        .args(["scripts", "read", "res://test.gd", "--lines", "0:10"])
+        .assert()
+        .code(2);
+}
+
+#[test]
+fn scripts_read_rejects_inverted_line_range() {
+    Command::cargo_bin("gdmcp")
+        .unwrap()
+        .args(["scripts", "read", "res://test.gd", "--lines", "20:10"])
+        .assert()
+        .code(2);
+}
+
+#[test]
+fn scripts_read_allows_open_ended_range() {
+    let mut command = Command::cargo_bin("gdmcp").unwrap();
+    command
+        .args([
+            "--json",
+            "--url",
+            "http://127.0.0.1:1",
+            "--timeout",
+            "1",
+            "scripts",
+            "read",
+            "res://test.gd",
+            "--lines",
+            "50:",
+        ])
+        .assert()
+        .code(4);
+}
+
+#[test]
+fn nodes_properties_set_is_accepted() {
+    let mut command = Command::cargo_bin("gdmcp").unwrap();
+    command
+        .args([
+            "--json",
+            "--url",
+            "http://127.0.0.1:1",
+            "--timeout",
+            "1",
+            "nodes",
+            "properties",
+            "set",
+            "/root/Player",
+            "--property",
+            "speed",
+            "--value",
+            "300",
+        ])
+        .assert()
+        .code(4);
+}
+
+#[test]
+fn nodes_get_accepts_fields() {
+    let mut command = Command::cargo_bin("gdmcp").unwrap();
+    command
+        .args([
+            "--json",
+            "--url",
+            "http://127.0.0.1:1",
+            "--timeout",
+            "1",
+            "nodes",
+            "get",
+            "/root/Player",
+            "--fields",
+            "position,visible",
+        ])
+        .assert()
+        .code(4);
+}
+
+#[test]
+fn runtime_nodes_subcommands_are_accepted() {
+    for subcommand in ["get", "set", "call"] {
+        let mut command = Command::cargo_bin("gdmcp").unwrap();
+        let mut args = vec![
+            "--json",
+            "--url",
+            "http://127.0.0.1:1",
+            "--timeout",
+            "1",
+            "runtime",
+            "nodes",
+            subcommand,
+            "/root/Main",
+        ];
+        if subcommand == "set" {
+            args.extend_from_slice(&["--property", "speed", "--value", "100"]);
+        } else if subcommand == "call" {
+            args.extend_from_slice(&["--method", "queue_free"]);
+        }
+        command.args(args).assert().code(4);
+    }
+}

--- a/skills/gdmcp/SKILL.md
+++ b/skills/gdmcp/SKILL.md
@@ -21,12 +21,15 @@ gdmcp --json scenes current
 gdmcp --json scenes list --limit 20
 gdmcp --json scenes tree --depth 4
 gdmcp --json nodes list --limit 20
+gdmcp --json nodes get /root/Main/Player --fields position,visible
+gdmcp --json nodes properties set /root/Main/Player --property speed --value 300
 gdmcp --json scripts list --limit 20
-gdmcp --json scripts read res://player.gd
+gdmcp --json scripts read res://player.gd --lines 1:200
 gdmcp --json resources list --limit 20
 gdmcp --json project settings --filter display/
 gdmcp --json debug logs --limit 50
 gdmcp --json runtime tree --depth 4
+gdmcp --json runtime nodes get /root/Main/Player
 ```
 
 When a domain command is unavailable, use progressive discovery:
@@ -37,17 +40,29 @@ gdmcp --json tools schema <tool-name>
 gdmcp --json tool-call <tool-name> --args-file <request.json>
 ```
 
+Commands not yet available as domain commands (use `tool-call` instead):
+
+- `scenes resolve`, `nodes resolve`, `scripts resolve`, `resources resolve`
+- `nodes move`, `nodes rename`
+- `scripts create`
+- `resources get`, `resources create`
+- `runtime nodes set`, `runtime nodes call` (use `tool-call`
+
+with the underlying tool and `--allow-open-world`)
+
 Rules:
 
 - Use `--json` when the output will be analyzed programmatically.
 - Prefer domain commands over raw `tool-call`.
 - Do not request the complete catalog with full schemas.
-- Bound output with `--limit`, `--depth`, `--fields`, `--max-bytes`, or `--out`.
+- Bound output with `--limit`, `--depth`, `--fields`, `--lines`, `--max-bytes`, or `--out`.
 - Use `scripts list --limit <n> [--cursor <cursor>]` for progressive script discovery.
+- Use `scripts read --lines <start>:<end>` to read specific line ranges and avoid loading entire large scripts into context. Pass `--lines 50:` for everything from line 50 onward.
 - Bound `scenes list`, `nodes list`, and `resources list` with `--limit`; use `--cursor` when continuing a result set.
 - `scenes list`, `nodes list`, `scripts list`, `resources list`, and `debug logs` default to 50 items; use a positive `--limit` and never pass zero.
 - Use `debug logs --cursor <offset>` to continue log pages; add `--out <file>` when the received result is large.
 - Always pass `project settings --filter <prefix>`; the unfiltered settings set can be too large.
+- Use `nodes get --fields <field1,field2>` to retrieve only specific properties instead of the full property dictionary.
 - Use `batch preview` before `batch apply`.
 - Batch validation completes before any request is sent; execution is sequential and non-atomic, so a later failure does not roll back earlier operations.
 - Batch files use registered tool names and object arguments, for example:

--- a/skills/gdmcp/references/command-workflows.md
+++ b/skills/gdmcp/references/command-workflows.md
@@ -13,14 +13,20 @@ gdmcp --json debug logs --level Error --limit 50
 
 ```bash
 gdmcp --json scenes tree --depth 4
-gdmcp --json nodes get /root/Main/Player
+gdmcp --json nodes get /root/Main/Player --fields position,visible
 ```
 
 ## Inspect a script
 
 ```bash
 gdmcp --json scripts list --limit 50
-gdmcp --json scripts read res://scripts/player.gd
+gdmcp --json scripts read res://scripts/player.gd --lines 1:200
+```
+
+## Modify a node property
+
+```bash
+gdmcp --json nodes properties set /root/Main/Player --property speed --value 300
 ```
 
 ## Replace a script explicitly
@@ -29,6 +35,22 @@ gdmcp --json scripts read res://scripts/player.gd
 gdmcp --json scripts replace res://scripts/player.gd \
   --content-file ./player.gd \
   --apply
+```
+
+## Inspect a running game
+
+```bash
+gdmcp --json runtime info
+gdmcp --json runtime tree --depth 4
+gdmcp --json runtime nodes get /root/Main/Player
+```
+
+## Inspect logs progressively
+
+```bash
+gdmcp --json debug logs --limit 50
+gdmcp --json debug logs --limit 50 --cursor 50
+gdmcp --json debug logs --limit 100 --out ./logs.json
 ```
 
 ## Discover an advanced runtime tool
@@ -51,3 +73,15 @@ gdmcp --json batch apply ./operations.json --apply
 Batch operations use registered tool names with JSON object arguments. They are
 validated before the first request, then executed sequentially and are not
 atomic; a later failure does not roll back earlier operations.
+
+## Commands not yet available as domain commands
+
+Use `tool-call` with the appropriate underlying tool for these operations:
+
+- Resource resolution / retrieval / creation → `list_project_resources`, etc.
+- Script creation → `create_script`
+- Node move / rename → `move_node`, `rename_node`
+- Scene / node / script resolution → list then match by exact path
+- Runtime node property modification or method calls → use `tool-call` with
+  `update_runtime_node_property` or `call_runtime_node_method` and
+  `--allow-open-world`


### PR DESCRIPTION
## Summary
Align gdmcp CLI with authoritative design spec.

## Changes
- **scripts read --lines**: Line-range slicing for bounded script output
- **nodes get --fields**: Property filtering to reduce context usage
- **nodes set → nodes properties set**: Nested subcommand matching design spec
- **runtime node → runtime nodes get|set|call**: Full get/set/call subcommands
- **SKILL.md / command-workflows.md**: Updated to match; unavailable commands noted

## Verified
- Live Godot 4.7.1 — all commands functional
- 35 Rust tests pass, cargo fmt + clippy clean