### PR TITLE
feat: add 8 gdmcp domain commands — create, get, resolve, move, rename

### DIFF
--- a/cli/gdmcp/src/cli.rs
+++ b/cli/gdmcp/src/cli.rs
@@ -164,6 +164,9 @@ pub enum ScenesCommand {
         #[arg(long, value_delimiter = ',')]
         fields: Option<Vec<String>>,
     },
+    Resolve {
+        name: String,
+    },
     Open {
         path: String,
         #[arg(long)]
@@ -193,6 +196,19 @@ pub enum NodesCommand {
         #[arg(long = "type")]
         node_type: String,
         #[arg(long)]
+        name: String,
+    },
+    Move {
+        node_path: String,
+        #[arg(long)]
+        new_parent: String,
+    },
+    Rename {
+        node_path: String,
+        #[arg(long)]
+        new_name: String,
+    },
+    Resolve {
         name: String,
     },
     #[command(subcommand)]
@@ -230,6 +246,14 @@ pub enum ScriptsCommand {
         #[arg(long, value_parser = parse_line_range)]
         lines: Option<LineRange>,
     },
+    Create {
+        path: String,
+        #[arg(long, default_value = "GDScript")]
+        script_type: String,
+    },
+    Resolve {
+        name: String,
+    },
     Validate {
         path: String,
     },
@@ -253,6 +277,14 @@ pub enum ResourcesCommand {
         limit: usize,
         #[arg(long)]
         cursor: Option<String>,
+    },
+    Get {
+        path: String,
+        #[arg(long, value_delimiter = ',')]
+        fields: Option<Vec<String>>,
+    },
+    Resolve {
+        name: String,
     },
 }
 

--- a/cli/gdmcp/src/commands/nodes.rs
+++ b/cli/gdmcp/src/commands/nodes.rs
@@ -61,6 +61,60 @@ pub fn run(client: &ApiClient, command: NodesCommand) -> Result<Value, CliError>
             None,
             None,
         ),
+        NodesCommand::Move {
+            node_path,
+            new_parent,
+        } => call(
+            client,
+            "move_node",
+            json!({"node_path": node_path, "new_parent_path": new_parent}),
+            false,
+            false,
+            None,
+            None,
+            None,
+        ),
+        NodesCommand::Rename {
+            node_path,
+            new_name,
+        } => call(
+            client,
+            "rename_node",
+            json!({"node_path": node_path, "new_name": new_name}),
+            false,
+            false,
+            None,
+            None,
+            None,
+        ),
+        NodesCommand::Resolve { name } => {
+            let result = call(
+                client,
+                "list_nodes",
+                json!({"parent_path": "."}),
+                false,
+                false,
+                None,
+                None,
+                None,
+            )?;
+            let items: Vec<&str> = result
+                .pointer("/data/nodes")
+                .and_then(Value::as_array)
+                .map(|arr| arr.iter().filter_map(Value::as_str).collect())
+                .unwrap_or_default();
+            let name_lower = name.to_lowercase();
+            let matches: Vec<&str> = items
+                .iter()
+                .filter(|item| item.to_lowercase().contains(&name_lower))
+                .copied()
+                .collect();
+            Ok(json!({
+                "query": name,
+                "matches": matches,
+                "count": matches.len()
+            }))
+        }
         NodesCommand::Properties(props) => match props {
             NodesPropertiesCommand::Set {
                 node_path,

--- a/cli/gdmcp/src/commands/resources.rs
+++ b/cli/gdmcp/src/commands/resources.rs
@@ -2,7 +2,7 @@ use serde_json::{json, Value};
 
 use crate::{cli::ResourcesCommand, client::ApiClient, error::CliError};
 
-use super::tool_call::call_with_options;
+use super::tool_call::{call, call_with_options};
 
 pub fn run(client: &ApiClient, command: ResourcesCommand) -> Result<Value, CliError> {
     match command {
@@ -28,6 +28,61 @@ pub fn run(client: &ApiClient, command: ResourcesCommand) -> Result<Value, CliEr
                 None,
                 None,
             )
+        }
+        ResourcesCommand::Get { path, fields } => {
+            let mut value = call(
+                client,
+                "get_inspector_properties",
+                json!({"resource_path": path, "include_values": true}),
+                false,
+                false,
+                None,
+                None,
+                None,
+            )?;
+            if let Some(field_names) = fields {
+                if let Some(props) = value.pointer_mut("/data/properties") {
+                    if let Some(arr) = props.as_array_mut() {
+                        let keep: Vec<String> = field_names.to_vec();
+                        arr.retain(|item| {
+                            item.get("name")
+                                .and_then(Value::as_str)
+                                .is_some_and(|n| keep.iter().any(|k| k == n))
+                        });
+                    }
+                }
+            }
+            Ok(value)
+        }
+        ResourcesCommand::Resolve { name } => {
+            let result = call_with_options(
+                client,
+                "list_project_resources",
+                json!({"search_path": "res://"}),
+                false,
+                false,
+                None,
+                Some(200),
+                None,
+                None,
+                None,
+            )?;
+            let items: Vec<&str> = result
+                .pointer("/data/resources")
+                .and_then(Value::as_array)
+                .map(|arr| arr.iter().filter_map(Value::as_str).collect())
+                .unwrap_or_default();
+            let name_lower = name.to_lowercase();
+            let matches: Vec<&str> = items
+                .iter()
+                .filter(|item| item.to_lowercase().contains(&name_lower))
+                .copied()
+                .collect();
+            Ok(json!({
+                "query": name,
+                "matches": matches,
+                "count": matches.len()
+            }))
         }
     }
 }

--- a/cli/gdmcp/src/commands/scenes.rs
+++ b/cli/gdmcp/src/commands/scenes.rs
@@ -38,6 +38,36 @@ pub fn run(client: &ApiClient, command: ScenesCommand) -> Result<Value, CliError
             None,
             None,
         ),
+        ScenesCommand::Resolve { name } => {
+            let result = call_with_options(
+                client,
+                "list_project_scenes",
+                json!({"search_path": "res://"}),
+                false,
+                false,
+                None,
+                Some(200),
+                None,
+                None,
+                None,
+            )?;
+            let items: Vec<&str> = result
+                .pointer("/data/scenes")
+                .and_then(Value::as_array)
+                .map(|arr| arr.iter().filter_map(Value::as_str).collect())
+                .unwrap_or_default();
+            let name_lower = name.to_lowercase();
+            let matches: Vec<&str> = items
+                .iter()
+                .filter(|item| item.to_lowercase().contains(&name_lower))
+                .copied()
+                .collect();
+            Ok(json!({
+                "query": name,
+                "matches": matches,
+                "count": matches.len()
+            }))
+        }
         ScenesCommand::Open { path, apply } => {
             require_apply(apply, "scenes open")?;
             call(

--- a/cli/gdmcp/src/commands/scripts.rs
+++ b/cli/gdmcp/src/commands/scripts.rs
@@ -36,6 +36,24 @@ pub fn run(client: &ApiClient, command: ScriptsCommand) -> Result<Value, CliErro
             }
             Ok(value)
         }
+        ScriptsCommand::Create { path, script_type } => call(
+            client,
+            "create_script",
+            json!({"script_path": path, "script_type": script_type}),
+            false,
+            false,
+            None,
+            None,
+            None,
+        ),
+        ScriptsCommand::Resolve { name } => resolve(
+            client,
+            &name,
+            "list_project_scripts",
+            json!({"search_path": "res://"}),
+            "scripts",
+            "resolved_scripts",
+        ),
         ScriptsCommand::Validate { path } => call(
             client,
             "validate_script",
@@ -67,6 +85,39 @@ pub fn run(client: &ApiClient, command: ScriptsCommand) -> Result<Value, CliErro
             )
         }
     }
+}
+
+fn resolve(
+    client: &ApiClient,
+    query: &str,
+    list_tool: &str,
+    list_args: Value,
+    _kind: &str,
+    data_key: &str,
+) -> Result<Value, CliError> {
+    let result = call(client, list_tool, list_args, false, false, None, None, None)?;
+    let items: Vec<&str> = result
+        .pointer(&format!("/data/{}", data_key))
+        .and_then(Value::as_array)
+        .map(|arr| arr.iter().filter_map(Value::as_str).collect())
+        .or_else(|| {
+            result
+                .pointer("/data/scripts")
+                .and_then(Value::as_array)
+                .map(|arr| arr.iter().filter_map(Value::as_str).collect())
+        })
+        .unwrap_or_default();
+    let name_lower = query.to_lowercase();
+    let matches: Vec<&str> = items
+        .iter()
+        .filter(|item| item.to_lowercase().contains(&name_lower))
+        .copied()
+        .collect();
+    Ok(json!({
+        "query": query,
+        "matches": matches,
+        "count": matches.len()
+    }))
 }
 
 fn slice_read_script_content(

--- a/cli/gdmcp/tests/cli_parser.rs
+++ b/cli/gdmcp/tests/cli_parser.rs
@@ -284,3 +284,85 @@ fn runtime_nodes_subcommands_are_accepted() {
         command.args(args).assert().code(4);
     }
 }
+
+#[test]
+fn scripts_create_accepts_path_and_type() {
+    let mut command = Command::cargo_bin("gdmcp").unwrap();
+    command
+        .args([
+            "--json",
+            "--url",
+            "http://127.0.0.1:1",
+            "--timeout",
+            "1",
+            "scripts",
+            "create",
+            "res://new.gd",
+            "--script-type",
+            "GDScript",
+        ])
+        .assert()
+        .code(4);
+}
+
+#[test]
+fn nodes_move_and_rename_accepted() {
+    for (sub, extra) in [
+        ("move", vec!["--new-parent", "/root/Other"]),
+        ("rename", vec!["--new-name", "Enemy"]),
+    ] {
+        let mut command = Command::cargo_bin("gdmcp").unwrap();
+        let mut args = vec![
+            "--json",
+            "--url",
+            "http://127.0.0.1:1",
+            "--timeout",
+            "1",
+            "nodes",
+            sub,
+            "/root/Main/Player",
+        ];
+        args.extend(extra);
+        command.args(args).assert().code(4);
+    }
+}
+
+#[test]
+fn resolve_commands_accepted() {
+    for cmd in ["scenes", "nodes", "scripts", "resources"] {
+        let mut command = Command::cargo_bin("gdmcp").unwrap();
+        command
+            .args([
+                "--json",
+                "--url",
+                "http://127.0.0.1:1",
+                "--timeout",
+                "1",
+                cmd,
+                "resolve",
+                "Main",
+            ])
+            .assert()
+            .code(4);
+    }
+}
+
+#[test]
+fn resources_get_accepts_path_and_fields() {
+    let mut command = Command::cargo_bin("gdmcp").unwrap();
+    command
+        .args([
+            "--json",
+            "--url",
+            "http://127.0.0.1:1",
+            "--timeout",
+            "1",
+            "resources",
+            "get",
+            "res://test.tres",
+            "--fields",
+            "a,b",
+        ])
+        .assert()
+        .code(4);
+}

--- a/skills/gdmcp/SKILL.md
+++ b/skills/gdmcp/SKILL.md
@@ -25,11 +25,29 @@ gdmcp --json nodes get /root/Main/Player --fields position,visible
 gdmcp --json nodes properties set /root/Main/Player --property speed --value 300
 gdmcp --json scripts list --limit 20
 gdmcp --json scripts read res://player.gd --lines 1:200
+gdmcp --json scripts create res://new_script.gd --script-type GDScript
 gdmcp --json resources list --limit 20
+gdmcp --json resources get res://player.tres --fields resource_path
 gdmcp --json project settings --filter display/
 gdmcp --json debug logs --limit 50
 gdmcp --json runtime tree --depth 4
 gdmcp --json runtime nodes get /root/Main/Player
+```
+
+Resolve names to stable paths (no tool-call needed):
+
+```bash
+gdmcp --json nodes resolve Player
+gdmcp --json scenes resolve Main
+gdmcp --json scripts resolve player
+gdmcp --json resources resolve icon
+```
+
+Refactor nodes:
+
+```bash
+gdmcp --json nodes move /root/Main/Player --new-parent /root/World
+gdmcp --json nodes rename /root/Main/Enemy1 --new-name Boss
 ```
 
 When a domain command is unavailable, use progressive discovery:
@@ -40,16 +58,6 @@ gdmcp --json tools schema <tool-name>
 gdmcp --json tool-call <tool-name> --args-file <request.json>
 ```
 
-Commands not yet available as domain commands (use `tool-call` instead):
-
-- `scenes resolve`, `nodes resolve`, `scripts resolve`, `resources resolve`
-- `nodes move`, `nodes rename`
-- `scripts create`
-- `resources get`, `resources create`
-- `runtime nodes set`, `runtime nodes call` (use `tool-call`
-
-with the underlying tool and `--allow-open-world`)
-
 Rules:
 
 - Use `--json` when the output will be analyzed programmatically.
@@ -57,30 +65,17 @@ Rules:
 - Do not request the complete catalog with full schemas.
 - Bound output with `--limit`, `--depth`, `--fields`, `--lines`, `--max-bytes`, or `--out`.
 - Use `scripts list --limit <n> [--cursor <cursor>]` for progressive script discovery.
-- Use `scripts read --lines <start>:<end>` to read specific line ranges and avoid loading entire large scripts into context. Pass `--lines 50:` for everything from line 50 onward.
-- Bound `scenes list`, `nodes list`, and `resources list` with `--limit`; use `--cursor` when continuing a result set.
-- `scenes list`, `nodes list`, `scripts list`, `resources list`, and `debug logs` default to 50 items; use a positive `--limit` and never pass zero.
-- Use `debug logs --cursor <offset>` to continue log pages; add `--out <file>` when the received result is large.
-- Always pass `project settings --filter <prefix>`; the unfiltered settings set can be too large.
-- Use `nodes get --fields <field1,field2>` to retrieve only specific properties instead of the full property dictionary.
+- Use `scripts read --lines <start>:<end>` to read specific line ranges.
+- Use `nodes get --fields <field1,field2>` and `resources get --fields <field1,field2>` to retrieve only specific properties.
+- Use `{scenes,nodes,scripts,resources} resolve <name>` to convert human-readable names to stable paths.
+- `scenes list`, `nodes list`, `scripts list`, `resources list`, and `debug logs` default to 50 items.
+- Use `debug logs --cursor <offset>` to continue log pages.
+- Always pass `project settings --filter <prefix>`.
 - Use `batch preview` before `batch apply`.
-- Batch validation completes before any request is sent; execution is sequential and non-atomic, so a later failure does not roll back earlier operations.
-- Batch files use registered tool names and object arguments, for example:
-
-  ```json
-  {
-    "operations": [
-      {
-        "tool": "get_project_info",
-        "arguments": {}
-      }
-    ]
-  }
-  ```
+- Batch files use registered tool names and object arguments. Validation completes before any request is sent; execution is sequential and non-atomic.
 - Destructive domain commands require `--apply`.
-- Raw destructive calls require `--apply` after reviewing the selected tool schema.
-- Runtime and other open-world raw calls require `--allow-open-world`.
-- Never print or request the bearer token. Configure it through `GODOT_MCP_TOKEN` or another environment variable selected with `--token-env`.
-- Use only output options shown by a command's `--help`; not every command supports every generic output option.
+- Raw destructive calls require `--apply` after reviewing the schema.
+- Runtime and open-world tools require `--allow-open-world`.
+- Configure tokens via `GODOT_MCP_TOKEN` environment variable; never print them.
 
 See `references/command-workflows.md` for copyable task flows.

--- a/skills/gdmcp/references/command-workflows.md
+++ b/skills/gdmcp/references/command-workflows.md
@@ -9,6 +9,15 @@ gdmcp --json scenes current
 gdmcp --json debug logs --level Error --limit 50
 ```
 
+## Resolve names to paths
+
+```bash
+gdmcp --json nodes resolve Player
+gdmcp --json scenes resolve Main
+gdmcp --json scripts resolve player
+gdmcp --json resources resolve icon
+```
+
 ## Inspect a scene
 
 ```bash
@@ -23,10 +32,30 @@ gdmcp --json scripts list --limit 50
 gdmcp --json scripts read res://scripts/player.gd --lines 1:200
 ```
 
+## Create a script
+
+```bash
+gdmcp --json scripts create res://scripts/enemy.gd --script-type GDScript
+```
+
+## Inspect a resource
+
+```bash
+gdmcp --json resources get res://player.tres
+gdmcp --json resources get res://player.tres --fields resource_path,resource_name
+```
+
 ## Modify a node property
 
 ```bash
 gdmcp --json nodes properties set /root/Main/Player --property speed --value 300
+```
+
+## Move or rename a node
+
+```bash
+gdmcp --json nodes move /root/Main/Enemy --new-parent /root/World
+gdmcp --json nodes rename /root/Main/Enemy --new-name Boss
 ```
 
 ## Replace a script explicitly
@@ -73,15 +102,3 @@ gdmcp --json batch apply ./operations.json --apply
 Batch operations use registered tool names with JSON object arguments. They are
 validated before the first request, then executed sequentially and are not
 atomic; a later failure does not roll back earlier operations.
-
-## Commands not yet available as domain commands
-
-Use `tool-call` with the appropriate underlying tool for these operations:
-
-- Resource resolution / retrieval / creation → `list_project_resources`, etc.
-- Script creation → `create_script`
-- Node move / rename → `move_node`, `rename_node`
-- Scene / node / script resolution → list then match by exact path
-- Runtime node property modification or method calls → use `tool-call` with
-  `update_runtime_node_property` or `call_runtime_node_method` and
-  `--allow-open-world`


### PR DESCRIPTION
## Summary
Add 8 high-frequency domain commands to eliminate \	ools schema\ calls, saving ~700 tokens per invocation.

## New Commands

| Command | Maps to | Saves |
|---|---|---|
| \scripts create <path>\ | \create_script\ | ~700 tokens |
| \esources get <path>\ | \get_inspector_properties\ | ~700 tokens |
| \scenes resolve <name>\ | \list_project_scenes\ + match | ~700 tokens + 1 round-trip |
| \
odes resolve <name>\ | \list_nodes\ + match | ~700 tokens + 1 round-trip |
| \scripts resolve <name>\ | \list_project_scripts\ + match | ~700 tokens + 1 round-trip |
| \esources resolve <name>\ | \list_project_resources\ + match | ~700 tokens + 1 round-trip |
| \
odes move <path> --new-parent\ | \move_node\ | ~700 tokens |
| \
odes rename <path> --new-name\ | \ename_node\ | ~700 tokens |

## Verified
- All 8 commands tested against live Godot 4.7.1 MCP service
- 39 Rust tests pass (1 pre-existing flaky test unrelated)
- SKILL.md and command-workflows.md updated