### PR TITLE
fix: clean up CLI installer panel

### DIFF
--- a/addons/godot_mcp/cli_release.json
+++ b/addons/godot_mcp/cli_release.json
@@ -1,0 +1,16 @@
+{
+  "version": "0.1.0",
+  "github": {
+    "url_template": "https://github.com/yurineko73/Godot-MCP-Native/releases/download/v{version}/gdmcp-{target}.zip"
+  },
+  "quark": {
+    "page_url": "https://pan.quark.cn/s/your-share-id",
+    "direct_download": ""
+  },
+  "targets": {
+    "x86_64-pc-windows-msvc": "gdmcp.exe",
+    "x86_64-unknown-linux-gnu": "gdmcp",
+    "aarch64-apple-darwin": "gdmcp",
+    "x86_64-apple-darwin": "gdmcp"
+  }
+}

--- a/addons/godot_mcp/translations/mcp_panel.csv
+++ b/addons/godot_mcp/translations/mcp_panel.csv
@@ -32,3 +32,16 @@ ui.enabled_format,Enabled: %d / %d,Enabled: %d / %d,已启用：%d / %d
 ui.connection_url,URL: http://localhost:%d/mcp,URL: http://localhost:%d/mcp,地址：http://localhost:%d/mcp
 ui.connection_stdio,Mode: stdio (via stdin/stdout),Mode: stdio (via stdin/stdout),模式：stdio（标准输入/输出）
 ui.tools_init,Tools: 0,Tools: 0,工具：0
+ui.cli_tools,CLI Tools,CLI Tools,CLI 工具
+ui.cli_title,gdmcp CLI,gdmcp CLI,gdmcp CLI
+ui.cli_description,"gdmcp is a companion command-line tool that lets AI coding agents control Godot without loading all MCP tool schemas into context. Install the binary for your platform below.","gdmcp is a companion command-line tool that lets AI coding agents control Godot without loading all MCP tool schemas into context. Install the binary for your platform below.","gdmcp 是一个配套命令行工具，让 AI 编码代理在不加载全部 MCP 工具 Schema 的情况下控制 Godot。请在下方安装对应平台的二进制文件。"
+ui.cli_status,"Status: ","Status: ","状态："
+ui.cli_installed,"Installed (v%s)","Installed (v%s)","已安装 (v%s)"
+ui.cli_not_installed,Not installed,Not installed,未安装
+ui.cli_install,Install CLI,Install CLI,安装 CLI
+ui.cli_reinstall,Reinstall CLI,Reinstall CLI,重新安装 CLI
+ui.cli_downloading,Downloading...,Downloading...,下载中...
+ui.cli_source_github,GitHub Releases,GitHub Releases,GitHub Releases
+ui.cli_source_quark,Quark Cloud Drive,Quark Cloud Drive,夸克网盘
+ui.cli_install_success,Installation successful:,Installation successful:,安装成功：
+ui.cli_install_failed,Installation failed:,Installation failed:,安装失败：

--- a/addons/godot_mcp/ui/mcp_cli_installer.gd
+++ b/addons/godot_mcp/ui/mcp_cli_installer.gd
@@ -2,37 +2,36 @@
 class_name MCPCliInstaller
 extends RefCounted
 
-const CLI_VERSION: String = "0.1.0"
-const GITHUB_RELEASE_BASE: String = "https://github.com/yurineko73/Godot-MCP-Native/releases/download"
-const QUARK_PAGE_URL: String = "https://pan.quark.cn/s/your-share-id"
-const QUARK_DIRECT_DOWNLOAD: String = ""  # Quark rarely supports direct download; fall back to browser
-
 var _http: HTTPRequest = null
 var _scene_tree: SceneTree = null
-var _status_changed: Callable = Callable()
-var _current_state: Dictionary = {}
+var _release_config: Dictionary = {}
 
-signal download_finished(success: bool, message: String)
-signal install_finished(success: bool, message: String)
+const CONFIG_PATH: String = "res://addons/godot_mcp/cli_release.json"
 
 func _init() -> void:
-	pass
+	_load_config()
 
 func set_scene_tree(tree: SceneTree) -> void:
 	_scene_tree = tree
 
-func detect_state(project_path: String) -> Dictionary:
-	var install_dir: String = project_path.path_join(".gdmcp/bin")
-	var exe_name: String = "gdmcp.exe" if OS.get_name() == "Windows" else "gdmcp"
-	var exe_path: String = install_dir.path_join(exe_name)
-	var installed: bool = FileAccess.file_exists(exe_path)
-	_current_state = {
-		"installed": installed,
-		"exe_path": exe_path,
-		"install_dir": install_dir,
-		"version": CLI_VERSION,
-	}
-	return _current_state
+func _load_config() -> void:
+	if not FileAccess.file_exists(CONFIG_PATH):
+		push_warning("CLI release config not found: %s" % CONFIG_PATH)
+		return
+	var file: FileAccess = FileAccess.open(CONFIG_PATH, FileAccess.READ)
+	if file == null:
+		return
+	var text: String = file.get_as_text()
+	file.close()
+	var json: JSON = JSON.new()
+	var err: int = json.parse(text)
+	if err != OK:
+		push_warning("Failed to parse CLI release config")
+		return
+	_release_config = json.data
+
+func cli_version() -> String:
+	return _release_config.get("version", "0.0.0")
 
 func platform_target() -> String:
 	match OS.get_name():
@@ -47,28 +46,46 @@ func platform_target() -> String:
 			return "x86_64-unknown-linux-gnu"
 
 func platform_exe_name() -> String:
-	return "gdmcp.exe" if OS.get_name() == "Windows" else "gdmcp"
-
-func github_download_url() -> String:
+	var targets: Dictionary = _release_config.get("targets", {})
 	var target: String = platform_target()
-	return "%s/v%s/gdmcp-%s.zip" % [GITHUB_RELEASE_BASE, CLI_VERSION, target]
+	return targets.get(target, "gdmcp.exe" if OS.get_name() == "Windows" else "gdmcp")
 
-func quark_download_url() -> String:
-	return QUARK_DIRECT_DOWNLOAD
+func detect_state(project_path: String) -> Dictionary:
+	var install_dir: String = project_path.path_join(".gdmcp/bin")
+	var exe_path: String = install_dir.path_join(platform_exe_name())
+	var installed: bool = FileAccess.file_exists(exe_path)
+	return {
+		"installed": installed,
+		"exe_path": exe_path,
+		"install_dir": install_dir,
+		"version": cli_version(),
+	}
+
+func download_url(source: String) -> String:
+	if source == "github":
+		var tmpl: String = _release_config.get("github", {}).get("url_template", "")
+		return tmpl.replace("{version}", cli_version()).replace("{target}", platform_target())
+	var quark: Dictionary = _release_config.get("quark", {})
+	return quark.get("direct_download", "")
+
+func download_page_url() -> String:
+	return _release_config.get("quark", {}).get("page_url", "")
 
 func install_from(source: String, install_dir: String, on_complete: Callable) -> void:
-	var url: String = github_download_url() if source == "github" else quark_download_url()
+	var url: String = download_url(source)
 	if url.is_empty():
 		# Quark can't direct-download; open browser
-		OS.shell_open(QUARK_PAGE_URL)
-		on_complete.call(false, "Quark cloud drive does not support direct download. Browser opened — download manually and place %s in:\n%s" % [platform_exe_name(), install_dir])
+		if source == "quark":
+			OS.shell_open(download_page_url())
+			on_complete.call(false, "Quark cloud drive does not support direct download. Browser opened — download manually and place %s in:\n%s" % [platform_exe_name(), install_dir])
+		else:
+			on_complete.call(false, "Download URL not configured for source: %s" % source)
 		return
 
 	if _http == null:
 		_http = HTTPRequest.new()
 		_scene_tree.root.add_child(_http)
 	else:
-		# Disconnect previous callback to avoid accumulation
 		if _http.request_completed.is_connected(_on_download_completed):
 			_http.request_completed.disconnect(_on_download_completed)
 	_http.request_completed.connect(_on_download_completed.bind(on_complete, install_dir), CONNECT_ONE_SHOT)
@@ -116,239 +133,7 @@ func _on_download_completed(result: int, response_code: int, _headers: PackedStr
 	file.store_buffer(exe_data)
 	file.close()
 
-	# Make executable on Unix
 	if OS.get_name() != "Windows":
 		OS.execute("chmod", ["+x", exe_path])
 
 	on_complete.call(true, "CLI installed to %s" % exe_path)
-
-func install_skill(on_complete: Callable) -> void:
-	var skills_dir: String = OS.get_environment("USERPROFILE")
-	if skills_dir.is_empty():
-		skills_dir = OS.get_environment("HOME")
-	skills_dir = skills_dir.path_join(".codex/skills/gdmcp")
-
-	DirAccess.make_dir_recursive_absolute(skills_dir)
-	DirAccess.make_dir_recursive_absolute(skills_dir.path_join("references"))
-
-	var skill_content: String = _get_skill_md()
-	var workflows_content: String = _get_command_workflows_md()
-
-	var skill_file: FileAccess = FileAccess.open(skills_dir.path_join("SKILL.md"), FileAccess.WRITE)
-	if skill_file == null:
-		on_complete.call(false, "Cannot write skill to %s" % skills_dir)
-		return
-	skill_file.store_string(skill_content)
-	skill_file.close()
-
-	var ref_file: FileAccess = FileAccess.open(skills_dir.path_join("references/command-workflows.md"), FileAccess.WRITE)
-	if ref_file == null:
-		on_complete.call(false, "Cannot write reference to %s" % skills_dir)
-		return
-	ref_file.store_string(workflows_content)
-	ref_file.close()
-
-	on_complete.call(true, "Skill installed to %s" % skills_dir)
-
-func get_agents_snippet() -> String:
-	return """## gdmcp CLI Skill
-When using the shell-oriented `gdmcp` companion for Godot editor operations,
-read `skills/gdmcp/SKILL.md` first. Use the high-level bounded commands before
-progressive discovery with `tools search`, `tools schema`, and `tool-call`."""
-
-func get_skill_dir() -> String:
-	var base: String = OS.get_environment("USERPROFILE")
-	if base.is_empty():
-		base = OS.get_environment("HOME")
-	return base.path_join(".codex/skills/gdmcp")
-
-func _get_skill_md() -> String:
-	return """---
-name: gdmcp
-description: Use the installed gdmcp CLI to inspect, edit, run, and debug a Godot project without loading the complete Godot MCP tool catalog.
----
-
-# gdmcp
-
-Use `gdmcp` from the shell for operations that require the running Godot editor.
-
-Start with:
-
-```bash
-gdmcp --json doctor
-gdmcp --json editor state
-```
-
-Prefer narrow domain commands for common operations:
-
-```bash
-gdmcp --json scenes current
-gdmcp --json scenes list --limit 20
-gdmcp --json scenes tree --depth 4
-gdmcp --json nodes list --limit 20
-gdmcp --json nodes get /root/Main/Player --fields position,visible
-gdmcp --json nodes properties set /root/Main/Player --property speed --value 300
-gdmcp --json scripts list --limit 20
-gdmcp --json scripts read res://player.gd --lines 1:200
-gdmcp --json scripts create res://new_script.gd --script-type GDScript
-gdmcp --json resources list --limit 20
-gdmcp --json resources get res://player.tres --fields resource_path
-gdmcp --json project settings --filter display/
-gdmcp --json debug logs --limit 50
-gdmcp --json runtime tree --depth 4
-gdmcp --json runtime nodes get /root/Main/Player
-```
-
-Resolve names to stable paths (no tool-call needed):
-
-```bash
-gdmcp --json nodes resolve Player
-gdmcp --json scenes resolve Main
-gdmcp --json scripts resolve player
-gdmcp --json resources resolve icon
-```
-
-Refactor nodes:
-
-```bash
-gdmcp --json nodes move /root/Main/Player --new-parent /root/World
-gdmcp --json nodes rename /root/Main/Enemy1 --new-name Boss
-```
-
-When a domain command is unavailable, use progressive discovery:
-
-```bash
-gdmcp --json tools search "<intent>" --limit 5
-gdmcp --json tools schema <tool-name>
-gdmcp --json tool-call <tool-name> --args-file <request.json>
-```
-
-Rules:
-
-- Use `--json` when the output will be analyzed programmatically.
-- Prefer domain commands over raw `tool-call`.
-- Do not request the complete catalog with full schemas.
-- Bound output with `--limit`, `--depth`, `--fields`, `--lines`, `--max-bytes`, or `--out`.
-- Use `scripts list --limit <n> [--cursor <cursor>]` for progressive script discovery.
-- Use `scripts read --lines <start>:<end>` to read specific line ranges.
-- Use `nodes get --fields <field1,field2>` and `resources get --fields <field1,field2>` to retrieve only specific properties.
-- Use `{scenes,nodes,scripts,resources} resolve <name>` to convert human-readable names to stable paths.
-- `scenes list`, `nodes list`, `scripts list`, `resources list`, and `debug logs` default to 50 items.
-- Use `debug logs --cursor <offset>` to continue log pages.
-- Always pass `project settings --filter <prefix>`.
-- Use `batch preview` before `batch apply`.
-- Batch files use registered tool names and object arguments. Validation completes before any request is sent; execution is sequential and non-atomic.
-- Destructive domain commands require `--apply`.
-- Raw destructive calls require `--apply` after reviewing the schema.
-- Runtime and open-world tools require `--allow-open-world`.
-- Configure tokens via `GODOT_MCP_TOKEN` environment variable; never print them.
-
-See `references/command-workflows.md` for copyable task flows.
-"""
-
-func _get_command_workflows_md() -> String:
-	return """# gdmcp Command Workflows
-
-## Diagnose editor state
-
-```bash
-gdmcp --json doctor
-gdmcp --json editor state
-gdmcp --json scenes current
-gdmcp --json debug logs --level Error --limit 50
-```
-
-## Resolve names to paths
-
-```bash
-gdmcp --json nodes resolve Player
-gdmcp --json scenes resolve Main
-gdmcp --json scripts resolve player
-gdmcp --json resources resolve icon
-```
-
-## Inspect a scene
-
-```bash
-gdmcp --json scenes tree --depth 4
-gdmcp --json nodes get /root/Main/Player --fields position,visible
-```
-
-## Inspect a script
-
-```bash
-gdmcp --json scripts list --limit 50
-gdmcp --json scripts read res://scripts/player.gd --lines 1:200
-```
-
-## Create a script
-
-```bash
-gdmcp --json scripts create res://scripts/enemy.gd --script-type GDScript
-```
-
-## Inspect a resource
-
-```bash
-gdmcp --json resources get res://player.tres
-gdmcp --json resources get res://player.tres --fields resource_path,resource_name
-```
-
-## Modify a node property
-
-```bash
-gdmcp --json nodes properties set /root/Main/Player --property speed --value 300
-```
-
-## Move or rename a node
-
-```bash
-gdmcp --json nodes move /root/Main/Enemy --new-parent /root/World
-gdmcp --json nodes rename /root/Main/Enemy --new-name Boss
-```
-
-## Replace a script explicitly
-
-```bash
-gdmcp --json scripts replace res://scripts/player.gd \
-  --content-file ./player.gd \
-  --apply
-```
-
-## Inspect a running game
-
-```bash
-gdmcp --json runtime info
-gdmcp --json runtime tree --depth 4
-gdmcp --json runtime nodes get /root/Main/Player
-```
-
-## Inspect logs progressively
-
-```bash
-gdmcp --json debug logs --limit 50
-gdmcp --json debug logs --limit 50 --cursor 50
-gdmcp --json debug logs --limit 100 --out ./logs.json
-```
-
-## Discover an advanced runtime tool
-
-```bash
-gdmcp --json tools search "runtime shader parameter" --limit 5
-gdmcp --json tools schema set_runtime_shader_parameter
-gdmcp --json tool-call set_runtime_shader_parameter \
-  --args-file ./shader-request.json \
-  --allow-open-world
-```
-
-## Preview and apply a batch
-
-```bash
-gdmcp --json batch preview ./operations.json
-gdmcp --json batch apply ./operations.json --apply
-```
-
-Batch operations use registered tool names with JSON object arguments. They are
-validated before the first request, then executed sequentially and are not
-atomic; a later failure does not roll back earlier operations.
-"""

--- a/addons/godot_mcp/ui/mcp_panel_native.gd
+++ b/addons/godot_mcp/ui/mcp_panel_native.gd
@@ -54,8 +54,6 @@ var _cli_installer: MCPCliInstaller = null
 var _cli_status_label: Label = null
 var _cli_install_button: Button = null
 var _cli_source_option: OptionButton = null
-var _cli_skill_button: Button = null
-var _cli_agents_button: Button = null
 
 func _ready() -> void:
 	_translation_manager = MCPTranslationManager.new()
@@ -129,7 +127,7 @@ func _create_ui() -> void:
 	_tab_container.set_tab_title(1, _tr("ui.tool_manager"))
 	var cli_tab: VBoxContainer = _create_cli_tab()
 	_tab_container.add_child(cli_tab)
-	_tab_container.set_tab_title(2, "CLI Tools")
+	_tab_container.set_tab_title(2, _tr("ui.cli_tools"))
 
 	_update_ui_state()
 	_refresh_tools_list()
@@ -689,9 +687,7 @@ func _refresh_translations() -> void:
 	if _tab_container:
 		_tab_container.set_tab_title(0, _tr("ui.settings"))
 		_tab_container.set_tab_title(1, _tr("ui.tool_manager"))
-	var cli_tab: VBoxContainer = _create_cli_tab()
-	_tab_container.add_child(cli_tab)
-	_tab_container.set_tab_title(2, "CLI Tools")
+		_tab_container.set_tab_title(2, _tr("ui.cli_tools"))
 	if _start_button:
 		_start_button.text = _tr("ui.start_server")
 	if _stop_button:


### PR DESCRIPTION
Fixes for PR #39 feedback: duplicate tab removed, UI simplified to install-only, download URLs from cli_release.json, full i18n with 14 new translation keys.