### PR TITLE
feat: skill download button, release automation script and skill

### DIFF
--- a/addons/godot_mcp/translations/mcp_panel.csv
+++ b/addons/godot_mcp/translations/mcp_panel.csv
@@ -34,7 +34,7 @@ ui.connection_stdio,Mode: stdio (via stdin/stdout),Mode: stdio (via stdin/stdout
 ui.tools_init,Tools: 0,Tools: 0,工具：0
 ui.cli_tools,CLI Tools,CLI Tools,CLI 工具
 ui.cli_title,gdmcp CLI,gdmcp CLI,gdmcp CLI
-ui.cli_description,"gdmcp is a companion command-line tool that lets AI coding agents control Godot without loading all MCP tool schemas into context. Install the binary for your platform below.","gdmcp is a companion command-line tool that lets AI coding agents control Godot without loading all MCP tool schemas into context. Install the binary for your platform below.","gdmcp 是一个配套命令行工具，让 AI 编码代理在不加载全部 MCP 工具 Schema 的情况下控制 Godot。请在下方安装对应平台的二进制文件。"
+ui.cli_description,"gdmcp is a companion CLI that lets AI agents control Godot without loading 154 MCP tool schemas into context. Install the binary below, then install the Codex skill from the GitHub repository (skills/gdmcp/).","gdmcp is a companion CLI that lets AI agents control Godot without loading 154 MCP tool schemas into context. Install the binary below, then install the Codex skill from the GitHub repository (skills/gdmcp/).","gdmcp 是一个配套 CLI 工具，让 AI 代理在不加载 154 个 MCP 工具 Schema 的情况下控制 Godot。请在下方安装二进制文件，然后从 GitHub 仓库安装 Codex 技能 (skills/gdmcp/)。"
 ui.cli_status,"Status: ","Status: ","状态："
 ui.cli_installed,"Installed (v%s)","Installed (v%s)","已安装 (v%s)"
 ui.cli_not_installed,Not installed,Not installed,未安装

--- a/addons/godot_mcp/translations/mcp_panel.csv
+++ b/addons/godot_mcp/translations/mcp_panel.csv
@@ -45,3 +45,5 @@ ui.cli_source_github,GitHub Releases,GitHub Releases,GitHub Releases
 ui.cli_source_quark,Quark Cloud Drive,Quark Cloud Drive,夸克网盘
 ui.cli_install_success,Installation successful:,Installation successful:,安装成功：
 ui.cli_install_failed,Installation failed:,Installation failed:,安装失败：
+
+ui.cli_skill_download,"Open Skill on GitHub","Open Skill on GitHub","在 GitHub 上查看 Skill"

--- a/addons/godot_mcp/ui/mcp_panel_native.gd
+++ b/addons/godot_mcp/ui/mcp_panel_native.gd
@@ -57,6 +57,7 @@ var _cli_status_title_label: Label = null
 var _cli_status_label: Label = null
 var _cli_install_button: Button = null
 var _cli_source_option: OptionButton = null
+var _cli_skill_button: Button = null
 
 func _ready() -> void:
 	_translation_manager = MCPTranslationManager.new()
@@ -941,6 +942,13 @@ func _create_cli_tab() -> VBoxContainer:
 	_cli_install_button.pressed.connect(_on_cli_install_pressed)
 	install_hbox.add_child(_cli_install_button)
 
+	var skill_hbox: HBoxContainer = HBoxContainer.new()
+	content.add_child(skill_hbox)
+	_cli_skill_button = Button.new()
+	_cli_skill_button.text = _tr("ui.cli_skill_download")
+	_cli_skill_button.pressed.connect(_on_cli_skill_download_pressed)
+	skill_hbox.add_child(_cli_skill_button)
+
 	return tab
 
 func _init_cli_installer() -> void:
@@ -964,6 +972,8 @@ func _refresh_cli_translations() -> void:
 	if _cli_source_option:
 		_cli_source_option.set_item_text(0, _tr("ui.cli_source_github"))
 		_cli_source_option.set_item_text(1, _tr("ui.cli_source_quark"))
+	if _cli_skill_button:
+		_cli_skill_button.text = _tr("ui.cli_skill_download")
 	_refresh_cli_status()
 
 func _refresh_cli_status() -> void:
@@ -1003,6 +1013,9 @@ func _on_cli_install_completed(success: bool, message: String) -> void:
 		_show_cli_message(_tr("ui.cli_install_failed") + "\n" + message)
 	_refresh_cli_status()
 
+
+func _on_cli_skill_download_pressed() -> void:
+	OS.shell_open("https://github.com/yurineko73/Godot-MCP-Native/tree/main/skills/gdmcp")
 
 func _show_cli_message(text: String) -> void:
 	var dialog: AcceptDialog = AcceptDialog.new()

--- a/docs/development/release-workflow.md
+++ b/docs/development/release-workflow.md
@@ -1,0 +1,152 @@
+# Release Workflow
+
+This document describes the complete release process for the Godot MCP Native plugin
+and its companion `gdmcp` CLI tool.
+
+## Overview
+
+The project ships two artifacts:
+
+| Artifact | Distribution | Platform |
+|---|---|---|
+| Godot MCP Native plugin (`addons/godot_mcp/`) | Godot Asset Library + GitHub Releases | Godot 4.6+ |
+| gdmcp CLI (`gdmcp.exe` / `gdmcp`) | GitHub Releases | Windows / Linux / macOS |
+
+## Versioning
+
+Both the plugin and CLI share the same version number. The plugin version is declared in:
+
+- `addons/godot_mcp/plugin.cfg` — `version` field
+- `addons/godot_mcp/cli_release.json` — `version` field (must match CLI binary)
+- `addons/godot_mcp/native_mcp/mcp_types.gd` — `PLUGIN_VERSION` constant (used for MCP serverInfo)
+
+The CLI version is declared in:
+
+- `cli/gdmcp/Cargo.toml` — `version` field
+- `addons/godot_mcp/cli_release.json` — `version` field (read by the installer panel)
+
+> **Rule:** All version numbers must be updated together before tagging a release.
+
+## Release Checklist
+
+### Step 1: Bump version numbers
+
+Update all version declarations:
+
+```text
+addons/godot_mcp/plugin.cfg          version = "X.Y.Z"
+addons/godot_mcp/cli_release.json    "version": "X.Y.Z"
+addons/godot_mcp/native_mcp/mcp_types.gd   PLUGIN_VERSION
+cli/gdmcp/Cargo.toml                 version = "X.Y.Z"
+```
+
+Also update `addons/godot_mcp/cli_release.json` with the correct Quark cloud drive
+share URL if applicable.
+
+### Step 2: Run full test suite
+
+```powershell
+# GUT unit tests
+& "F:\Godot\Godot_v4.6.1-stable_win64.exe" --headless --path "." -s addons/gut/gut_cmdln.gd -gdir=res://test/unit/ -ginclude_subdirs -gexit
+
+# Python integration tests
+python test/integration/test_cli_api_flow.py
+
+# Rust tests
+cargo test --manifest-path cli/gdmcp/Cargo.toml --locked
+cargo clippy --manifest-path cli/gdmcp/Cargo.toml --all-targets --locked -- -D warnings
+cargo fmt --manifest-path cli/gdmcp/Cargo.toml --check
+
+# Packaging tests
+python test/integration/test_gdmcp_packaging.py
+```
+
+### Step 3: Build and package CLI
+
+```powershell
+# Windows
+./cli/gdmcp/scripts/package.ps1 -Version X.Y.Z -Target x86_64-pc-windows-msvc
+
+# Linux (on Linux host)
+./cli/gdmcp/scripts/package.sh X.Y.Z x86_64-unknown-linux-gnu
+
+# macOS (on macOS host)
+./cli/gdmcp/scripts/package.sh X.Y.Z x86_64-apple-darwin
+./cli/gdmcp/scripts/package.sh X.Y.Z aarch64-apple-darwin
+```
+
+Packages are output to `dist/`:
+
+```text
+dist/gdmcp-X.Y.Z-x86_64-pc-windows-msvc.zip
+dist/gdmcp-X.Y.Z-x86_64-unknown-linux-gnu.zip
+dist/gdmcp-X.Y.Z-x86_64-apple-darwin.zip
+dist/gdmcp-X.Y.Z-aarch64-apple-darwin.zip
+```
+
+### Step 4: Prepare plugin archive
+
+Package the `addons/godot_mcp/` directory for Godot Asset Library:
+
+```powershell
+Compress-Archive -Path addons/godot_mcp/* -DestinationPath dist/godot-mcp-native-X.Y.Z.zip
+```
+
+### Step 5: Create GitHub Release
+
+1. Go to [GitHub Releases](https://github.com/yurineko73/Godot-MCP-Native/releases)
+2. Click "Draft a new release"
+3. Tag: `vX.Y.Z`
+4. Title: `vX.Y.Z`
+5. Upload all files from `dist/`:
+   - `godot-mcp-native-X.Y.Z.zip` (plugin archive)
+   - `gdmcp-X.Y.Z-x86_64-pc-windows-msvc.zip`
+   - `gdmcp-X.Y.Z-x86_64-unknown-linux-gnu.zip`
+   - `gdmcp-X.Y.Z-x86_64-apple-darwin.zip`
+   - `gdmcp-X.Y.Z-aarch64-apple-darwin.zip`
+6. Write release notes (see `docs/release-notes/` for templates)
+
+### Step 6: Update Godot Asset Library
+
+1. Go to [Godot Asset Library](https://godotengine.org/asset-library/)
+2. Submit the `godot-mcp-native-X.Y.Z.zip` archive
+3. Edit the asset listing description if needed
+
+### Step 7: Update Quark cloud drive (optional)
+
+Upload the same zip files to Quark cloud drive and update the `page_url` in
+`addons/godot_mcp/cli_release.json` if sharing a new link.
+
+### Step 8: Post-release
+
+```powershell
+# Update main branch with any post-release fixes
+git checkout main
+git pull
+# Bump to next dev version if needed
+git checkout -b chore/bump-version-X.Y.Z+1-dev
+# ... update versions ...
+git push
+```
+
+## Skill Installation (for users)
+
+The `skills/gdmcp/` directory in the repository contains the companion Codex skill.
+Users must manually install it:
+
+```powershell
+# Copy skill to Codex skills directory
+Copy-Item -Recurse skills/gdmcp $env:USERPROFILE\.codex\skills\gdmcp
+```
+
+Users should also add the recommended snippet to their project's `AGENTS.md`:
+
+```markdown
+## gdmcp CLI Skill
+When using the shell-oriented `gdmcp` companion for Godot editor operations,
+read `skills/gdmcp/SKILL.md` first. Use the high-level bounded commands before
+progressive discovery with `tools search`, `tools schema`, and `tool-call`.
+```
+
+The CLI Tools tab in the MCP panel displays download instructions and the GitHub
+repository URL for these files.

--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -1,0 +1,130 @@
+<#
+.SYNOPSIS
+    Automate Godot MCP Native release steps 1-5.
+.DESCRIPTION
+    Bumps plugin and CLI versions, runs tests, builds CLI packages,
+    creates plugin archive, and creates a GitHub Release draft.
+    Asset Library submission (step 6) and Quark upload (step 7) remain manual.
+.PARAMETER Version
+    New version number (e.g. "1.1.0"). Required.
+.PARAMETER SkipTests
+    Skip test suite (for quick iteration; not recommended for actual release).
+.PARAMETER DryRun
+    Preview changes without writing any files or creating a release.
+.EXAMPLE
+    .\scripts\release.ps1 -Version 1.1.0
+    .\scripts\release.ps1 -Version 1.1.0 -SkipTests
+    .\scripts\release.ps1 -Version 1.1.0 -DryRun
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$Version,
+    [switch]$SkipTests,
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = "Stop"
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$PluginCfg = Join-Path $RepoRoot "addons\godot_mcp\plugin.cfg"
+$CliReleaseJson = Join-Path $RepoRoot "addons\godot_mcp\cli_release.json"
+$McpTypesGd = Join-Path $RepoRoot "addons\godot_mcp\native_mcp\mcp_types.gd"
+$CargoToml = Join-Path $RepoRoot "cli\gdmcp\Cargo.toml"
+$GodotExe = "F:\Godot\Godot_v4.6.1-stable_win64.exe"
+$DistDir = Join-Path $RepoRoot "dist"
+$PluginZip = Join-Path $DistDir "godot-mcp-native-$Version.zip"
+
+function Write-Step { param([string]$Text) Write-Host ">>> $Text" -ForegroundColor Cyan }
+
+# Step 1: Bump versions
+Write-Step "Step 1: Bump version to $Version"
+
+if (-not $DryRun) {
+    $cfg = Get-Content $PluginCfg -Raw
+    $cfg = $cfg -replace '(?m)^version="[^"]*"', "version=`"$Version`""
+    Set-Content $PluginCfg $cfg -NoNewline
+
+    $json = Get-Content $CliReleaseJson -Raw | ConvertFrom-Json
+    $json.version = $Version
+    $json | ConvertTo-Json -Depth 4 | Set-Content $CliReleaseJson -NoNewline
+
+    $types = Get-Content $McpTypesGd -Raw
+    $types = $types -replace 'const PLUGIN_VERSION\s*=\s*"[^"]*"', "const PLUGIN_VERSION = `"$Version`""
+    Set-Content $McpTypesGd $types -NoNewline
+
+    $cargo = Get-Content $CargoToml -Raw
+    $cargo = $cargo -replace '(?m)^version\s*=\s*"[^"]*"', "version = `"$Version`""
+    Set-Content $CargoToml $cargo -NoNewline
+
+    Write-Host "  Updated: plugin.cfg, cli_release.json, mcp_types.gd, Cargo.toml"
+} else {
+    Write-Host "  [DRY RUN] Would update 4 version files"
+}
+
+# Step 2: Tests
+if (-not $SkipTests) {
+    Write-Step "Step 2: Run test suite"
+    if (-not $DryRun) {
+        Write-Host "  Rust tests..."
+        $env:CARGO_HOME = Join-Path $RepoRoot ".gdmcp\cargo"
+        $env:RUSTUP_HOME = Join-Path $RepoRoot ".gdmcp\rustup"
+        $env:PATH = "$env:CARGO_HOME\bin;$env:PATH"
+        cargo test --manifest-path cli/gdmcp/Cargo.toml --locked
+        if ($LASTEXITCODE -ne 0) { throw "Rust tests failed" }
+        cargo clippy --manifest-path cli/gdmcp/Cargo.toml --all-targets --locked -- -D warnings
+        if ($LASTEXITCODE -ne 0) { throw "Clippy failed" }
+
+        Write-Host "  GUT tests..."
+        & $GodotExe --headless --path $RepoRoot -s addons/gut/gut_cmdln.gd -gdir=res://test/unit/ -ginclude_subdirs -gexit
+        if ($LASTEXITCODE -ne 0) { throw "GUT tests failed" }
+
+        Write-Host "  Packaging tests..."
+        python test/integration/test_gdmcp_packaging.py
+        if ($LASTEXITCODE -ne 0) { throw "Packaging tests failed" }
+        Write-Host "  All tests passed"
+    } else {
+        Write-Host "  [DRY RUN] Would run Rust + GUT + packaging tests"
+    }
+}
+
+# Step 3: Build CLI
+Write-Step "Step 3: Build CLI packages"
+if (-not $DryRun) {
+    $pkgScript = Join-Path $RepoRoot "cli\gdmcp\scripts\package.ps1"
+    & $pkgScript -Version $Version -Target "x86_64-pc-windows-msvc"
+    if ($LASTEXITCODE -ne 0) { throw "Windows package failed" }
+    Write-Host "  dist/gdmcp-$Version-x86_64-pc-windows-msvc.zip"
+} else {
+    Write-Host "  [DRY RUN] Would build Windows x64 package"
+}
+
+# Step 4: Plugin archive
+Write-Step "Step 4: Create plugin archive"
+if (-not $DryRun) {
+    New-Item -ItemType Directory -Force -Path $DistDir | Out-Null
+    Compress-Archive -Path "$RepoRoot\addons\godot_mcp\*" -DestinationPath $PluginZip -Force
+    Write-Host "  $PluginZip"
+} else {
+    Write-Host "  [DRY RUN] Would create $PluginZip"
+}
+
+# Step 5: GitHub Release
+Write-Step "Step 5: Create GitHub Release (draft)"
+if (-not $DryRun) {
+    $tag = "v$Version"
+    $notes = "Plugin: godot-mcp-native-$Version.zip`nCLI: gdmcp-$Version-x86_64-pc-windows-msvc.zip"
+    gh release create $tag --repo yurineko73/Godot-MCP-Native --draft --title "v$Version" --notes $notes `
+        $PluginZip (Join-Path $DistDir "gdmcp-$Version-x86_64-pc-windows-msvc.zip")
+    if ($LASTEXITCODE -ne 0) { throw "GitHub release creation failed" }
+    Write-Host "  Draft created: https://github.com/yurineko73/Godot-MCP-Native/releases"
+} else {
+    Write-Host "  [DRY RUN] Would create GitHub Release draft"
+}
+
+Write-Host ""
+Write-Host "=== Automated steps complete ===" -ForegroundColor Green
+Write-Host "Manual steps remaining:"
+Write-Host "  6. Submit plugin to Godot Asset Library"
+Write-Host "  7. Upload to Quark cloud drive (optional)"
+Write-Host "  8. Commit and push version changes"

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: release
+description: Automate Godot MCP Native plugin and CLI release. Bumps versions, runs tests, builds packages, creates GitHub Release draft.
+---
+
+# Release Godot MCP Native
+
+Use this skill when asked to release a new version of the Godot MCP Native plugin
+and gdmcp CLI.
+
+## Prerequisites
+
+- Rust toolchain installed at `.gdmcp/` (or system-wide cargo)
+- Godot 4.6.1 at `F:\Godot\Godot_v4.6.1-stable_win64.exe`
+- Python 3 with `test/integration/` dependencies
+- `gh` CLI authenticated with `yurineko73/Godot-MCP-Native` repo access
+
+## Workflow
+
+### 1. Run the release script
+
+```powershell
+.\scripts\release.ps1 -Version <X.Y.Z>
+```
+
+This automates:
+- Version bump in `plugin.cfg`, `cli_release.json`, `mcp_types.gd`, `Cargo.toml`
+- Full test suite (Rust tests + clippy + GUT + packaging)
+- CLI package build (Windows x64; Linux/macOS built separately)
+- Plugin archive (`dist/godot-mcp-native-X.Y.Z.zip`)
+- GitHub Release draft with artifacts uploaded
+
+Use `-DryRun` to preview without changes. Use `-SkipTests` for quick iteration.
+
+### 2. Build other platform packages (on their respective hosts)
+
+```bash
+# Linux
+./cli/gdmcp/scripts/package.sh X.Y.Z x86_64-unknown-linux-gnu
+
+# macOS
+./cli/gdmcp/scripts/package.sh X.Y.Z x86_64-apple-darwin
+./cli/gdmcp/scripts/package.sh X.Y.Z aarch64-apple-darwin
+```
+
+Upload the resulting zip files to the GitHub Release draft.
+
+### 3. Manual steps
+
+- Submit `godot-mcp-native-X.Y.Z.zip` to [Godot Asset Library](https://godotengine.org/asset-library/)
+- Upload packages to Quark cloud drive (optional), update `cli_release.json`
+- Publish the GitHub Release draft
+- Commit version bump: `git commit -m "chore: bump version to X.Y.Z"`
+
+### 4. Verify the release
+
+After publishing:
+
+```powershell
+# Install from GitHub Release
+gdmcp --json doctor
+
+# Verify the plugin panel shows correct version in Godot editor
+```
+
+## Troubleshooting
+
+- If `gh release create` fails, check `gh auth status`
+- If Rust tests fail, run `cargo test --manifest-path cli/gdmcp/Cargo.toml` directly
+- If GUT fails, open the project in Godot editor and run tests interactively
+- If packaging tests fail, check `test/integration/test_gdmcp_packaging.py`


### PR DESCRIPTION
CLI Tools tab: new button opens GitHub skills/gdmcp directory. Scripts/release.ps1 automates steps 1-5. Skills/release/SKILL.md teaches Codex the release workflow.