### PR TITLE
chore: set Quark cloud drive URL in cli_release.json

### DIFF
--- a/addons/godot_mcp/cli_release.json
+++ b/addons/godot_mcp/cli_release.json
@@ -4,8 +4,9 @@
     "url_template": "https://github.com/yurineko73/Godot-MCP-Native/releases/download/v{version}/gdmcp-{target}.zip"
   },
   "quark": {
-    "page_url": "https://pan.quark.cn/s/your-share-id",
-    "direct_download": ""
+    "page_url": "https://pan.quark.cn/s/69c412007005",
+    "direct_download": "",
+    "share_text": "我用夸克网盘给你分享了「Godot-mcp-native插件」，点击链接或复制整段内容，打开「夸克APP」即可获取。\n/~c0613ZmmXq~:/\n链接：https://pan.quark.cn/s/69c412007005"
   },
   "targets": {
     "x86_64-pc-windows-msvc": "gdmcp.exe",

--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -57,7 +57,7 @@ if (-not $DryRun) {
     $cargo = $cargo -replace '(?m)^version\s*=\s*"[^"]*"', "version = `"$Version`""
     Set-Content $CargoToml $cargo -NoNewline
 
-    Write-Host "  Updated: plugin.cfg, cli_release.json, mcp_types.gd, Cargo.toml"
+    Write-Host "  Updated: plugin.cfg (version), cli_release.json (version only; Quark URL preserved), mcp_types.gd, Cargo.toml"
 } else {
     Write-Host "  [DRY RUN] Would update 4 version files"
 }
@@ -126,5 +126,5 @@ Write-Host ""
 Write-Host "=== Automated steps complete ===" -ForegroundColor Green
 Write-Host "Manual steps remaining:"
 Write-Host "  6. Submit plugin to Godot Asset Library"
-Write-Host "  7. Upload to Quark cloud drive (optional)"
+Write-Host "  7. Upload new packages to Quark cloud drive (page_url is pre-configured in cli_release.json)"
 Write-Host "  8. Commit and push version changes"

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -48,7 +48,7 @@ Upload the resulting zip files to the GitHub Release draft.
 ### 3. Manual steps
 
 - Submit `godot-mcp-native-X.Y.Z.zip` to [Godot Asset Library](https://godotengine.org/asset-library/)
-- Upload packages to Quark cloud drive (optional), update `cli_release.json`
+- Upload packages to Quark cloud drive (share link pre-configured in cli_release.json; update only if Quark generates a new link)
 - Publish the GitHub Release draft
 - Commit version bump: `git commit -m "chore: bump version to X.Y.Z"`
 


### PR DESCRIPTION
Pre-configure Quark share URL. Release script preserves it across version bumps.