### PR TITLE
docs: add gdmcp CLI section to all READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,29 @@ A powerful Godot Engine plugin that integrates AI assistants (Claude, etc.) via 
   - **Debug Tools** (3 core + 68 advanced): Logging, debugger sessions, breakpoints, stack/variable inspection, profilers, runtime probe, animation/audio/shader/tilemap runtime control, debug execution control, await_scene_ready
   - **Project Tools** (3 core + 23 advanced): Access project settings, list resources, create resources, run tests, manage input mappings, inspect autoloads/global classes, resource diagnostics & health audit
 
+## 🖥️ gdmcp CLI (Agent-First Interface)
+
+For coding agents (Codex, Claude Code, Cursor) that have shell access, the **gdmcp CLI**
+is the recommended way to interact with Godot MCP. Instead of loading all 155 tool
+schemas into model context, the CLI uses progressive discovery — ~33 domain commands
+for common operations, and on-demand schema retrieval for supplementary tools.
+
+```bash
+# Quick start
+gdmcp --json doctor
+gdmcp --json scenes tree --depth 4
+gdmcp --json scripts read res://player.gd --lines 1:200
+gdmcp --json nodes properties set /root/Player --property speed --value 300
+```
+
+**Installation**: Open the Godot editor → MCP dock → **CLI Tools** tab, or download
+from [GitHub Releases](https://github.com/yurineko73/Godot-MCP-Native/releases).
+See the [CLI README](cli/gdmcp/README.md) and [CLI Reference](docs/current/gdmcp-cli-reference.md)
+for full documentation.
+
+**Skill**: Install the companion Codex skill from `skills/gdmcp/` to teach your
+agent the CLI workflow. Copy `skills/gdmcp/` to `~/.codex/skills/gdmcp/`.
+
 ## 📦 Installation
 
 ### Method 1: Asset Library (Recommended)
@@ -384,6 +407,8 @@ For detailed documentation, see the `docs/current/` folder:
 - [Quick Start Guide](docs/current/quickstart.md)
 - [Architecture Design](docs/current/architecture.md)
 - [Tools Reference](docs/current/tools-reference.md)
+- [CLI Reference](docs/current/gdmcp-cli-reference.md)
+- [Release Workflow](docs/development/release-workflow.md)
 - [Testing Guide](docs/current/testing-guide.md)
 
 ## 🤝 Contributing

--- a/README.zh.md
+++ b/README.zh.md
@@ -21,6 +21,27 @@
   - **调试工具**（3 核心 + 68 高级）：日志、调试会话、断点、栈帧/变量读取、性能分析器、运行时探针，动画/音频/着色器/瓦片地图运行时控制，调试执行控制
   - **项目工具**（3 核心 + 23 高级）：访问项目设置、列出资源、创建资源，运行测试、管理输入映射、检查自动加载/全局类，资源诊断与健康审计
 
+## 🖥️ gdmcp CLI（Agent 优先接口）
+
+对于有 Shell 访问权限的编程代理（Codex、Claude Code、Cursor），**gdmcp CLI**
+是与 Godot MCP 交互的推荐方式。CLI 不会将所有 155 个工具 Schema 加载到模型上下文中，
+而是使用渐进式发现——约 33 个领域命令用于常见操作，按需获取补充工具的 Schema。
+
+```bash
+# 快速开始
+gdmcp --json doctor
+gdmcp --json scenes tree --depth 4
+gdmcp --json scripts read res://player.gd --lines 1:200
+gdmcp --json nodes properties set /root/Player --property speed --value 300
+```
+
+**安装**：打开 Godot 编辑器 → MCP 面板 → **CLI Tools** 标签页，或从
+[GitHub Releases](https://github.com/yurineko73/Godot-MCP-Native/releases) 下载。
+完整文档见 [CLI README](cli/gdmcp/README.md) 和 [CLI Reference](docs/current/gdmcp-cli-reference.md)。
+
+**Skill**：从 `skills/gdmcp/` 安装配套 Codex Skill，教你的代理使用 CLI 工作流。
+将 `skills/gdmcp/` 复制到 `~/.codex/skills/gdmcp/`。
+
 ## 📦 安装
 
 ### 方法 1：资源库（推荐）
@@ -382,6 +403,8 @@ url = "http://localhost:9080/mcp"
 - [快速开始指南](docs/current/quickstart.md)
 - [架构设计](docs/current/architecture.md)
 - [工具参考](docs/current/tools-reference.md)
+- [CLI 参考](docs/current/gdmcp-cli-reference.md)
+- [发布流程](docs/development/release-workflow.md)
 - [测试指南](docs/current/testing-guide.md)
 
 ## 🤝 贡献

--- a/addons/godot_mcp/README.md
+++ b/addons/godot_mcp/README.md
@@ -21,6 +21,15 @@ A powerful Godot Engine plugin that integrates AI assistants (Claude, etc.) via 
   - **Debug Tools** (3 core + 68 advanced): Logging, debugger sessions, breakpoints, stack/variable inspection, profilers, runtime probe, animation/audio/shader/tilemap runtime control, debug execution control, await_scene_ready
   - **Project Tools** (3 core + 23 advanced): Access project settings, list resources, create resources, run tests, manage input mappings, inspect autoloads/global classes, resource diagnostics & health audit
 
+## 🖥️ gdmcp CLI
+
+This plugin includes a companion **gdmcp CLI** for coding agents (Codex, Claude Code, etc.)
+that reduces model context usage by ~30,000 tokens compared to MCP. Install it from the
+**CLI Tools** tab in the MCP dock panel, or download from
+[GitHub Releases](https://github.com/yurineko73/Godot-MCP-Native/releases).
+
+See [CLI README](../../cli/gdmcp/README.md) for details.
+
 ## 📦 Installation
 
 ### Method 1: Asset Library (Recommended)

--- a/addons/godot_mcp/README.zh.md
+++ b/addons/godot_mcp/README.zh.md
@@ -21,6 +21,14 @@
   - **调试工具**（3 核心 + 68 高级）：日志、调试会话、断点、栈帧/变量读取、性能分析器、运行时探针，动画/音频/着色器/瓦片地图运行时控制，调试执行控制，场景就绪等待
   - **项目工具**（3 核心 + 23 高级）：访问项目设置、列出资源、创建资源，运行测试、管理输入映射、检查自动加载/全局类，资源诊断与健康审计
 
+## 🖥️ gdmcp CLI
+
+本插件包含配套的 **gdmcp CLI**，供编程代理（Codex、Claude Code 等）使用，
+相比 MCP 可减少约 30,000 tokens 的上下文消耗。在 MCP 停靠面板的 **CLI Tools** 标签页中安装，
+或从 [GitHub Releases](https://github.com/yurineko73/Godot-MCP-Native/releases) 下载。
+
+详见 [CLI README](../../cli/gdmcp/README.md)。
+
 ## 📦 安装
 
 ### 方法 1：资源库（推荐）

--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -57,9 +57,24 @@ if (-not $DryRun) {
     $cargo = $cargo -replace '(?m)^version\s*=\s*"[^"]*"', "version = `"$Version`""
     Set-Content $CargoToml $cargo -NoNewline
 
-    Write-Host "  Updated: plugin.cfg (version), cli_release.json (version only; Quark URL preserved), mcp_types.gd, Cargo.toml"
+    # Update README version badges
+    $readmes = @(
+        (Join-Path $RepoRoot "README.md"),
+        (Join-Path $RepoRoot "README.zh.md"),
+        (Join-Path $RepoRoot "addons\godot_mcp\README.md"),
+        (Join-Path $RepoRoot "addons\godot_mcp\README.zh.md")
+    )
+    foreach ($rm in $readmes) {
+        if (Test-Path $rm) {
+            $rmContent = Get-Content $rm -Raw
+            $rmContent = $rmContent -replace 'Version-\d+\.\d+\.\d+', "Version-$Version"
+            Set-Content $rm $rmContent -NoNewline
+        }
+    }
+
+    Write-Host "  Updated: plugin.cfg, cli_release.json, mcp_types.gd, Cargo.toml, README badges (x4)"
 } else {
-    Write-Host "  [DRY RUN] Would update 4 version files"
+    Write-Host "  [DRY RUN] Would update 8 files (4 version files + 4 README badges)"
 }
 
 # Step 2: Tests
@@ -126,5 +141,5 @@ Write-Host ""
 Write-Host "=== Automated steps complete ===" -ForegroundColor Green
 Write-Host "Manual steps remaining:"
 Write-Host "  6. Submit plugin to Godot Asset Library"
-Write-Host "  7. Upload new packages to Quark cloud drive (page_url is pre-configured in cli_release.json)"
+Write-Host "  7. Upload to Quark cloud drive (page_url is pre-configured in cli_release.json)"
 Write-Host "  8. Commit and push version changes"


### PR DESCRIPTION
All 4 READMEs now document the gdmcp CLI. Release script auto-bumps version badges in READMEs.