### PR TITLE
docs: all README links absolute

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Godot MCP Native (Model Context Protocol)
 
-[中文版本](README.zh.md)
+[中文版本](https://github.com/yurineko73/Godot-MCP-Native/blob/main/README.zh.md)
 
 ![Godot Version](https://img.shields.io/badge/Godot-4.x-blue?logo=godot-engine)
 ![License](https://img.shields.io/badge/License-MIT-green)
@@ -417,7 +417,7 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 
 ## 📄 License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License - see the [LICENSE](https://github.com/yurineko73/Godot-MCP-Native/blob/main/LICENSE) file for details.
 
 ## 👤 Author
 

--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ gdmcp --json nodes properties set /root/Player --property speed --value 300
 
 **Installation**: Open the Godot editor → MCP dock → **CLI Tools** tab, or download
 from [GitHub Releases](https://github.com/yurineko73/Godot-MCP-Native/releases).
-See the [CLI README](cli/gdmcp/README.md) and [CLI Reference](docs/current/gdmcp-cli-reference.md)
+See the [CLI README](https://github.com/yurineko73/Godot-MCP-Native/blob/main/cli/gdmcp/README.md) and [CLI Reference](https://github.com/yurineko73/Godot-MCP-Native/blob/main/docs/current/gdmcp-cli-reference.md)
 for full documentation.
 
-**Skill**: Install the companion Codex skill from `skills/gdmcp/` to teach your
-agent the CLI workflow. Copy `skills/gdmcp/` to `~/.codex/skills/gdmcp/`.
+**Skill**: Install the companion Codex skill from [skills/gdmcp/](https://github.com/yurineko73/Godot-MCP-Native/blob/main/skills/gdmcp) to teach your
+agent the CLI workflow. Copy [skills/gdmcp/](https://github.com/yurineko73/Godot-MCP-Native/blob/main/skills/gdmcp) to `~/.codex/skills/gdmcp/`.
 
 ## 📦 Installation
 
@@ -404,12 +404,12 @@ Implement a day/night cycle system with dynamic lighting
 ## 📖 Documentation
 
 For detailed documentation, see the `docs/current/` folder:
-- [Quick Start Guide](docs/current/quickstart.md)
-- [Architecture Design](docs/current/architecture.md)
-- [Tools Reference](docs/current/tools-reference.md)
-- [CLI Reference](docs/current/gdmcp-cli-reference.md)
-- [Release Workflow](docs/development/release-workflow.md)
-- [Testing Guide](docs/current/testing-guide.md)
+- [Quick Start Guide](https://github.com/yurineko73/Godot-MCP-Native/blob/main/docs/current/quickstart.md)
+- [Architecture Design](https://github.com/yurineko73/Godot-MCP-Native/blob/main/docs/current/architecture.md)
+- [Tools Reference](https://github.com/yurineko73/Godot-MCP-Native/blob/main/docs/current/tools-reference.md)
+- [CLI Reference](https://github.com/yurineko73/Godot-MCP-Native/blob/main/docs/current/gdmcp-cli-reference.md)
+- [Release Workflow](https://github.com/yurineko73/Godot-MCP-Native/blob/main/docs/development/release-workflow.md)
+- [Testing Guide](https://github.com/yurineko73/Godot-MCP-Native/blob/main/docs/current/testing-guide.md)
 
 ## 🤝 Contributing
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,6 +1,6 @@
 # Godot MCP Native (模型上下文协议)
 
-[English Version](README.md)
+[English Version](https://github.com/yurineko73/Godot-MCP-Native/blob/main/README.md)
 
 ![Godot 版本](https://img.shields.io/badge/Godot-4.x-blue?logo=godot-engine)
 ![许可证](https://img.shields.io/badge/License-MIT-green)
@@ -413,7 +413,7 @@ url = "http://localhost:9080/mcp"
 
 ## 📄 许可证
 
-本项目采用 MIT 许可证 - 详见 [LICENSE](LICENSE) 文件。
+本项目采用 MIT 许可证 - 详见 [LICENSE](https://github.com/yurineko73/Godot-MCP-Native/blob/main/LICENSE) 文件。
 
 ## 👤 作者
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -37,10 +37,10 @@ gdmcp --json nodes properties set /root/Player --property speed --value 300
 
 **安装**：打开 Godot 编辑器 → MCP 面板 → **CLI Tools** 标签页，或从
 [GitHub Releases](https://github.com/yurineko73/Godot-MCP-Native/releases) 下载。
-完整文档见 [CLI README](cli/gdmcp/README.md) 和 [CLI Reference](docs/current/gdmcp-cli-reference.md)。
+完整文档见 [CLI README](https://github.com/yurineko73/Godot-MCP-Native/blob/main/cli/gdmcp/README.md) 和 [CLI Reference](https://github.com/yurineko73/Godot-MCP-Native/blob/main/docs/current/gdmcp-cli-reference.md)。
 
-**Skill**：从 `skills/gdmcp/` 安装配套 Codex Skill，教你的代理使用 CLI 工作流。
-将 `skills/gdmcp/` 复制到 `~/.codex/skills/gdmcp/`。
+**Skill**：从 [skills/gdmcp/](https://github.com/yurineko73/Godot-MCP-Native/blob/main/skills/gdmcp) 安装配套 Codex Skill，教你的代理使用 CLI 工作流。
+将 [skills/gdmcp/](https://github.com/yurineko73/Godot-MCP-Native/blob/main/skills/gdmcp) 复制到 `~/.codex/skills/gdmcp/`。
 
 ## 📦 安装
 
@@ -400,12 +400,12 @@ url = "http://localhost:9080/mcp"
 ## 📖 文档
 
 详细文档请查看 `docs/current/` 文件夹：
-- [快速开始指南](docs/current/quickstart.md)
-- [架构设计](docs/current/architecture.md)
-- [工具参考](docs/current/tools-reference.md)
-- [CLI 参考](docs/current/gdmcp-cli-reference.md)
-- [发布流程](docs/development/release-workflow.md)
-- [测试指南](docs/current/testing-guide.md)
+- [快速开始指南](https://github.com/yurineko73/Godot-MCP-Native/blob/main/docs/current/quickstart.md)
+- [架构设计](https://github.com/yurineko73/Godot-MCP-Native/blob/main/docs/current/architecture.md)
+- [工具参考](https://github.com/yurineko73/Godot-MCP-Native/blob/main/docs/current/tools-reference.md)
+- [CLI 参考](https://github.com/yurineko73/Godot-MCP-Native/blob/main/docs/current/gdmcp-cli-reference.md)
+- [发布流程](https://github.com/yurineko73/Godot-MCP-Native/blob/main/docs/development/release-workflow.md)
+- [测试指南](https://github.com/yurineko73/Godot-MCP-Native/blob/main/docs/current/testing-guide.md)
 
 ## 🤝 贡献
 

--- a/addons/godot_mcp/README.md
+++ b/addons/godot_mcp/README.md
@@ -1,6 +1,6 @@
 # Godot MCP Native (Model Context Protocol)
 
-[中文版本](README.zh.md)
+[中文版本](https://github.com/yurineko73/Godot-MCP-Native/blob/main/README.zh.md)
 
 ![Godot Version](https://img.shields.io/badge/Godot-4.x-blue?logo=godot-engine)
 ![License](https://img.shields.io/badge/License-MIT-green)
@@ -378,7 +378,7 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 
 ## 📄 License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License - see the [LICENSE](https://github.com/yurineko73/Godot-MCP-Native/blob/main/LICENSE) file for details.
 
 ## 👤 Author
 

--- a/addons/godot_mcp/README.md
+++ b/addons/godot_mcp/README.md
@@ -28,7 +28,7 @@ that reduces model context usage by ~30,000 tokens compared to MCP. Install it f
 **CLI Tools** tab in the MCP dock panel, or download from
 [GitHub Releases](https://github.com/yurineko73/Godot-MCP-Native/releases).
 
-See [CLI README](../../cli/gdmcp/README.md) for details.
+See [CLI README](https://github.com/yurineko73/Godot-MCP-Native/blob/main/cli/gdmcp/README.md) for details.
 
 ## 📦 Installation
 
@@ -367,10 +367,10 @@ Implement a day/night cycle system with dynamic lighting
 ## 📖 Documentation
 
 For detailed documentation, see the `docs/current/` folder:
-- [Quick Start Guide](docs/current/quickstart.md)
-- [Architecture Design](docs/current/architecture.md)
-- [Tools Reference](docs/current/tools-reference.md)
-- [Testing Guide](docs/current/testing-guide.md)
+- [Quick Start Guide](https://github.com/yurineko73/Godot-MCP-Native/blob/main/docs/current/quickstart.md)
+- [Architecture Design](https://github.com/yurineko73/Godot-MCP-Native/blob/main/docs/current/architecture.md)
+- [Tools Reference](https://github.com/yurineko73/Godot-MCP-Native/blob/main/docs/current/tools-reference.md)
+- [Testing Guide](https://github.com/yurineko73/Godot-MCP-Native/blob/main/docs/current/testing-guide.md)
 
 ## 🤝 Contributing
 

--- a/addons/godot_mcp/README.zh.md
+++ b/addons/godot_mcp/README.zh.md
@@ -27,7 +27,7 @@
 相比 MCP 可减少约 30,000 tokens 的上下文消耗。在 MCP 停靠面板的 **CLI Tools** 标签页中安装，
 或从 [GitHub Releases](https://github.com/yurineko73/Godot-MCP-Native/releases) 下载。
 
-详见 [CLI README](../../cli/gdmcp/README.md)。
+详见 [CLI README](https://github.com/yurineko73/Godot-MCP-Native/blob/main/cli/gdmcp/README.md)。
 
 ## 📦 安装
 
@@ -368,10 +368,10 @@ url = "http://localhost:9080/mcp"
 ## 📖 文档
 
 详细文档请查看 `docs/current/` 文件夹：
-- [快速开始指南](docs/current/quickstart.md)
-- [架构设计](docs/current/architecture.md)
-- [工具参考](docs/current/tools-reference.md)
-- [测试指南](docs/current/testing-guide.md)
+- [快速开始指南](https://github.com/yurineko73/Godot-MCP-Native/blob/main/docs/current/quickstart.md)
+- [架构设计](https://github.com/yurineko73/Godot-MCP-Native/blob/main/docs/current/architecture.md)
+- [工具参考](https://github.com/yurineko73/Godot-MCP-Native/blob/main/docs/current/tools-reference.md)
+- [测试指南](https://github.com/yurineko73/Godot-MCP-Native/blob/main/docs/current/testing-guide.md)
 
 ## 🤝 贡献
 

--- a/addons/godot_mcp/README.zh.md
+++ b/addons/godot_mcp/README.zh.md
@@ -1,6 +1,6 @@
 # Godot MCP Native (模型上下文协议)
 
-[English Version](README.md)
+[English Version](https://github.com/yurineko73/Godot-MCP-Native/blob/main/README.md)
 
 ![Godot 版本](https://img.shields.io/badge/Godot-4.x-blue?logo=godot-engine)
 ![许可证](https://img.shields.io/badge/License-MIT-green)
@@ -379,7 +379,7 @@ url = "http://localhost:9080/mcp"
 
 ## 📄 许可证
 
-本项目采用 MIT 许可证 - 详见 [LICENSE](LICENSE) 文件。
+本项目采用 MIT 许可证 - 详见 [LICENSE](https://github.com/yurineko73/Godot-MCP-Native/blob/main/LICENSE) 文件。
 
 ## 👤 作者
 


### PR DESCRIPTION
Language switchers and LICENSE links now also absolute GitHub URLs.