### PR TITLE
chore: bump version to 1.0.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![Godot Version](https://img.shields.io/badge/Godot-4.x-blue?logo=godot-engine)
 ![License](https://img.shields.io/badge/License-MIT-green)
-![Version](https://img.shields.io/badge/Version-1.0.7-brightgreen)
+![Version](https://img.shields.io/badge/Version-1.0.8-brightgreen)
 
 A powerful Godot Engine plugin that integrates AI assistants (Claude, etc.) via the Model Context Protocol (MCP). Enable AI to directly read and modify your Godot projects - scenes, scripts, nodes, and resources - all through natural language.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -4,7 +4,7 @@
 
 ![Godot 版本](https://img.shields.io/badge/Godot-4.x-blue?logo=godot-engine)
 ![许可证](https://img.shields.io/badge/License-MIT-green)
-![版本](https://img.shields.io/badge/Version-1.0.7-brightgreen)
+![版本](https://img.shields.io/badge/Version-1.0.8-brightgreen)
 
 一个强大的 Godot 引擎插件，通过模型上下文协议 (MCP) 集成 AI 助手（如 Claude 等）。让 AI 可以直接通过自然语言读取和修改您的 Godot 项目——场景、脚本、节点和资源。
 

--- a/addons/godot_mcp/README.md
+++ b/addons/godot_mcp/README.md
@@ -4,7 +4,7 @@
 
 ![Godot Version](https://img.shields.io/badge/Godot-4.x-blue?logo=godot-engine)
 ![License](https://img.shields.io/badge/License-MIT-green)
-![Version](https://img.shields.io/badge/Version-1.0.7-brightgreen)
+![Version](https://img.shields.io/badge/Version-1.0.8-brightgreen)
 
 A powerful Godot Engine plugin that integrates AI assistants (Claude, etc.) via the Model Context Protocol (MCP). Enable AI to directly read and modify your Godot projects - scenes, scripts, nodes, and resources - all through natural language.
 

--- a/addons/godot_mcp/README.zh.md
+++ b/addons/godot_mcp/README.zh.md
@@ -4,7 +4,7 @@
 
 ![Godot 版本](https://img.shields.io/badge/Godot-4.x-blue?logo=godot-engine)
 ![许可证](https://img.shields.io/badge/License-MIT-green)
-![版本](https://img.shields.io/badge/Version-1.0.7-brightgreen)
+![版本](https://img.shields.io/badge/Version-1.0.8-brightgreen)
 
 一个强大的 Godot 引擎插件，通过模型上下文协议 (MCP) 集成 AI 助手（如 Claude 等）。让 AI 可以直接通过自然语言读取和修改您的 Godot 项目——场景、脚本、节点和资源。
 

--- a/addons/godot_mcp/cli_release.json
+++ b/addons/godot_mcp/cli_release.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0",
+  "version": "1.0.8",
   "github": {
     "url_template": "https://github.com/yurineko73/Godot-MCP-Native/releases/download/v{version}/gdmcp-{target}.zip"
   },

--- a/addons/godot_mcp/plugin.cfg
+++ b/addons/godot_mcp/plugin.cfg
@@ -3,7 +3,7 @@
 name="Godot MCP Native"
 description="Integrate AI assistants (Claude, etc.) with Godot via Model Context Protocol. Supports scene editing, script management, and real-time debugging. No Node.js dependency required."
 author="yurineko73"
-version="1.0.7"
+version="1.0.8"
 script="mcp_server_native.gd"
 
 # 原生MCP服务器配置

--- a/cli/gdmcp/Cargo.lock
+++ b/cli/gdmcp/Cargo.lock
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "gdmcp"
-version = "0.1.0"
+version = "1.0.8"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/cli/gdmcp/Cargo.toml
+++ b/cli/gdmcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gdmcp"
-version = "0.1.0"
+version = "1.0.8"
 edition = "2021"
 description = "Agent-friendly CLI for Godot MCP Native"
 license = "MIT"

--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -85,9 +85,9 @@ if (-not $SkipTests) {
         $env:CARGO_HOME = Join-Path $RepoRoot ".gdmcp\cargo"
         $env:RUSTUP_HOME = Join-Path $RepoRoot ".gdmcp\rustup"
         $env:PATH = "$env:CARGO_HOME\bin;$env:PATH"
-        cargo test --manifest-path cli/gdmcp/Cargo.toml --locked
+        cargo test --manifest-path cli/gdmcp/Cargo.toml
         if ($LASTEXITCODE -ne 0) { throw "Rust tests failed" }
-        cargo clippy --manifest-path cli/gdmcp/Cargo.toml --all-targets --locked -- -D warnings
+        cargo clippy --manifest-path cli/gdmcp/Cargo.toml --all-targets -- -D warnings
         if ($LASTEXITCODE -ne 0) { throw "Clippy failed" }
 
         Write-Host "  GUT tests..."


### PR DESCRIPTION
Release v1.0.8 — bumps plugin.cfg, cli_release.json, Cargo.toml, and 4 README badges.