### PR TITLE
fix: include addons/ parent directory in plugin archive

### DIFF
--- a/docs/development/release-workflow.md
+++ b/docs/development/release-workflow.md
@@ -89,7 +89,9 @@ dist/gdmcp-X.Y.Z-aarch64-apple-darwin.zip
 Package the `addons/godot_mcp/` directory for Godot Asset Library:
 
 ```powershell
-Compress-Archive -Path addons/godot_mcp -DestinationPath dist/godot-mcp-native-X.Y.Z.zip
+# Stage with addons/ prefix
+Copy-Item -Recurse addons/godot_mcp $env:TEMP/staging/addons/godot_mcp
+Compress-Archive -Path $env:TEMP/staging/addons -DestinationPath dist/godot-mcp-native-X.Y.Z.zip
 ```
 
 ### Step 5: Create GitHub Release

--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -118,7 +118,13 @@ if (-not $DryRun) {
 Write-Step "Step 4: Create plugin archive"
 if (-not $DryRun) {
     New-Item -ItemType Directory -Force -Path $DistDir | Out-Null
-    Compress-Archive -Path "$RepoRoot\addons\godot_mcp" -DestinationPath $PluginZip -Force
+    # Stage with addons/ prefix so extracted path is addons/godot_mcp/
+    $staging = Join-Path ([IO.Path]::GetTempPath()) "gdmcp-zip-staging"
+    if (Test-Path $staging) { Remove-Item -Recurse -Force $staging }
+    New-Item -Path "$staging\addons" -ItemType Directory -Force | Out-Null
+    Copy-Item -Recurse -Force "$RepoRoot\addons\godot_mcp" "$staging\addons\godot_mcp"
+    Compress-Archive -Path "$staging\addons" -DestinationPath $PluginZip -Force
+    Remove-Item -Recurse -Force $staging
     Write-Host "  $PluginZip"
 } else {
     Write-Host "  [DRY RUN] Would create $PluginZip"


### PR DESCRIPTION
Zip now contains addons/godot_mcp/ so extracted path matches project structure.