### PR TITLE
为gdmcp构建添加Github Action

### DIFF
--- a/.github/workflows/build-gdmcp.yml
+++ b/.github/workflows/build-gdmcp.yml
@@ -26,6 +26,7 @@ jobs:
             target: aarch64-unknown-linux-gnu
             artifact: gdmcp
             archive: gdmcp-linux-arm64.tar.gz
+            linker: aarch64-linux-gnu-gcc
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             artifact: gdmcp.exe
@@ -56,6 +57,8 @@ jobs:
           sudo apt-get install -y gcc-aarch64-linux-gnu
 
       - name: Build
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: ${{ matrix.linker }}
         run: cargo build --manifest-path cli/gdmcp/Cargo.toml --release --target ${{ matrix.target }} --locked
 
       - name: Package (unix)

--- a/.github/workflows/build-gdmcp.yml
+++ b/.github/workflows/build-gdmcp.yml
@@ -1,0 +1,98 @@
+name: Build gdmcp
+
+on:
+  push:
+    tags:
+      - "v*"
+    paths:
+      - "cli/gdmcp/**"
+      - ".github/workflows/build-gdmcp.yml"
+  pull_request:
+    paths:
+      - "cli/gdmcp/**"
+      - ".github/workflows/build-gdmcp.yml"
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            artifact: gdmcp
+            archive: gdmcp-linux-amd64.tar.gz
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            artifact: gdmcp
+            archive: gdmcp-linux-arm64.tar.gz
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            artifact: gdmcp.exe
+            archive: gdmcp-windows-amd64.zip
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            artifact: gdmcp
+            archive: gdmcp-macos-arm64.tar.gz
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            artifact: gdmcp
+            archive: gdmcp-macos-amd64.tar.gz
+
+    runs-on: ${{ matrix.os }}
+    name: Build (${{ matrix.target }})
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross-compilation tools
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+
+      - name: Build
+        run: cargo build --manifest-path cli/gdmcp/Cargo.toml --release --target ${{ matrix.target }} --locked
+
+      - name: Package (unix)
+        if: runner.os != 'Windows'
+        run: |
+          cd cli/gdmcp/target/${{ matrix.target }}/release
+          tar czf ${{ matrix.archive }} ${{ matrix.artifact }}
+          mv ${{ matrix.archive }} ${{ github.workspace }}/
+
+      - name: Package (windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Compress-Archive -Path "cli/gdmcp/target/${{ matrix.target }}/release/${{ matrix.artifact }}" -DestinationPath ${{ matrix.archive }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.archive }}
+          path: ${{ matrix.archive }}
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: artifacts/*

--- a/cli/gdmcp/.cargo/config.toml
+++ b/cli/gdmcp/.cargo/config.toml
@@ -1,2 +1,0 @@
-[target.aarch64-unknown-linux-gnu]
-linker = "aarch64-linux-gnu-gcc"

--- a/cli/gdmcp/.cargo/config.toml
+++ b/cli/gdmcp/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"


### PR DESCRIPTION

## 概述

为 `gdmcp` CLI 工具添加 GitHub Actions 工作流，支持跨平台二进制文件构建。

### 变更内容

- 新增 `.github/workflows/build-gdmcp.yml`，矩阵构建 5 个目标平台：
  - `x86_64-unknown-linux-gnu`（Linux amd64）
  - `aarch64-unknown-linux-gnu`（Linux arm64）
  - `x86_64-pc-windows-msvc`（Windows amd64）
  - `aarch64-apple-darwin`（macOS arm64）
  - `x86_64-apple-darwin`（macOS amd64）
- 推送 `v*` 标签时自动创建 GitHub Release 并附带所有平台二进制文件
- 使用 `CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER` 环境变量解决 aarch64 交叉编译链接器问题

### 触发条件

- 推送到 `cli/gdmcp/**` 路径（CI 检查）
- Pull Request 涉及 `cli/gdmcp/**` 路径（CI 检查）
- 推送 `v*` 标签（构建 + 发布）
- 手动触发

### 测试

Linux amd64 测试通过：

<img width="1248" height="1478" alt="图片" src="https://github.com/user-attachments/assets/7b8f93b0-9843-49a2-8e64-7dc9e6ddbf0b" />

Fixes #56