### PR TITLE
ci: add manual multi-platform gdmcp release workflow

### DIFF
--- a/.github/workflows/manual-gdmcp-release.yml
+++ b/.github/workflows/manual-gdmcp-release.yml
@@ -1,0 +1,407 @@
+name: Manual gdmcp Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      replace_existing_assets:
+        description: Replace workflow-managed assets when the release already exists
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.prepare.outputs.version }}
+      tag: ${{ steps.prepare.outputs.tag }}
+      source_sha: ${{ steps.prepare.outputs.source_sha }}
+      tag_exists: ${{ steps.prepare.outputs.tag_exists }}
+      release_exists: ${{ steps.prepare.outputs.release_exists }}
+    steps:
+      - name: Check out selected revision
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - name: Resolve version, tag, and source commit
+        id: prepare
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPLACE_EXISTING_ASSETS: ${{ inputs.replace_existing_assets }}
+        run: |
+          set -euo pipefail
+
+          validate_versions() {
+            python - <<'PY'
+          import json
+          import re
+          import sys
+          import tomllib
+          from pathlib import Path
+
+          cargo_version = tomllib.loads(Path("cli/gdmcp/Cargo.toml").read_text(encoding="utf-8"))["package"]["version"]
+
+          plugin_text = Path("addons/godot_mcp/plugin.cfg").read_text(encoding="utf-8")
+          plugin_match = re.search(r'(?m)^version\s*=\s*"([^"]+)"\s*$', plugin_text)
+          if plugin_match is None:
+              raise SystemExit("plugin.cfg version was not found")
+          plugin_version = plugin_match.group(1)
+
+          release_config = json.loads(Path("addons/godot_mcp/cli_release.json").read_text(encoding="utf-8"))
+          release_version = str(release_config.get("version", ""))
+
+          if re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", cargo_version) is None:
+              raise SystemExit(f"Cargo.toml version is not X.Y.Z: {cargo_version}")
+
+          versions = {
+              "cli/gdmcp/Cargo.toml": cargo_version,
+              "addons/godot_mcp/plugin.cfg": plugin_version,
+              "addons/godot_mcp/cli_release.json": release_version,
+          }
+          if len(set(versions.values())) != 1:
+              for path, version in versions.items():
+                  print(f"{path}: {version}", file=sys.stderr)
+              raise SystemExit("release version declarations do not match")
+
+          print(cargo_version)
+          PY
+          }
+
+          candidate_version=$(validate_versions)
+          tag="v${candidate_version}"
+
+          git fetch --force --tags origin
+          if git rev-parse -q --verify "refs/tags/${tag}^{commit}" >/dev/null; then
+            tag_exists=true
+            source_sha=$(git rev-parse "refs/tags/${tag}^{commit}")
+          else
+            tag_exists=false
+            source_sha="$GITHUB_SHA"
+          fi
+
+          git checkout --detach "$source_sha"
+          resolved_version=$(validate_versions)
+          if [[ "$resolved_version" != "$candidate_version" ]]; then
+            echo "::error::Selected revision declares ${candidate_version}, but ${tag} resolves to a commit declaring ${resolved_version}."
+            exit 1
+          fi
+
+          if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            release_exists=true
+          else
+            release_exists=false
+          fi
+
+          if [[ "$release_exists" == true && "$REPLACE_EXISTING_ASSETS" != true ]]; then
+            echo "::error::Release ${tag} already exists. Re-run with replace_existing_assets enabled to replace only its managed assets."
+            exit 1
+          fi
+
+          {
+            echo "version=$resolved_version"
+            echo "tag=$tag"
+            echo "source_sha=$source_sha"
+            echo "tag_exists=$tag_exists"
+            echo "release_exists=$release_exists"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Version: $resolved_version"
+          echo "Tag: $tag"
+          echo "Source commit: $source_sha"
+          echo "Tag exists: $tag_exists"
+          echo "Release exists: $release_exists"
+
+  build-cli:
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            executable: gdmcp.exe
+          - os: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+            executable: gdmcp
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            executable: gdmcp
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            executable: gdmcp
+          - os: macos-15-intel
+            target: x86_64-apple-darwin
+            executable: gdmcp
+    runs-on: ${{ matrix.os }}
+    name: Build CLI (${{ matrix.target }})
+    steps:
+      - name: Check out release source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.source_sha }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build locked release binary
+        run: cargo build --manifest-path cli/gdmcp/Cargo.toml --release --locked --target ${{ matrix.target }}
+
+      - name: Create release ZIP
+        shell: bash
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+          TARGET: ${{ matrix.target }}
+          EXECUTABLE: ${{ matrix.executable }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+          import zipfile
+          from pathlib import Path
+
+          version = os.environ["VERSION"]
+          target = os.environ["TARGET"]
+          executable = os.environ["EXECUTABLE"]
+          cli_root = Path("cli/gdmcp")
+          binary = cli_root / "target" / target / "release" / executable
+          packaging = cli_root / "packaging"
+          output = Path("dist") / f"gdmcp-{version}-{target}.zip"
+
+          if not binary.is_file():
+              raise SystemExit(f"release binary was not produced: {binary}")
+
+          required = {
+              "install.ps1": packaging / "install.ps1",
+              "install.sh": packaging / "install.sh",
+              "README.md": packaging / "README.md",
+              "LICENSE": packaging / "LICENSE",
+          }
+          missing = [str(path) for path in required.values() if not path.is_file()]
+          if missing:
+              raise SystemExit("missing packaging files: " + ", ".join(missing))
+
+          output.parent.mkdir(parents=True, exist_ok=True)
+          digest = hashlib.sha256(binary.read_bytes()).hexdigest()
+          manifest = {
+              "schema_version": 1,
+              "package": "gdmcp",
+              "version": version,
+              "target": target,
+              "executable": executable,
+          }
+
+          def write_bytes(archive: zipfile.ZipFile, name: str, data: bytes, mode: int) -> None:
+              info = zipfile.ZipInfo(name, date_time=(1980, 1, 1, 0, 0, 0))
+              info.compress_type = zipfile.ZIP_DEFLATED
+              info.create_system = 3
+              info.external_attr = (mode & 0xFFFF) << 16
+              archive.writestr(info, data)
+
+          with zipfile.ZipFile(output, "w") as archive:
+              write_bytes(archive, executable, binary.read_bytes(), 0o755)
+              write_bytes(archive, "install.ps1", required["install.ps1"].read_bytes(), 0o644)
+              write_bytes(archive, "install.sh", required["install.sh"].read_bytes(), 0o755)
+              write_bytes(archive, "README.md", required["README.md"].read_bytes(), 0o644)
+              write_bytes(archive, "LICENSE", required["LICENSE"].read_bytes(), 0o644)
+              write_bytes(archive, "SHA256SUMS", f"{digest}  {executable}\n".encode(), 0o644)
+              write_bytes(
+                  archive,
+                  "release-manifest.json",
+                  (json.dumps(manifest, indent=2) + "\n").encode(),
+                  0o644,
+              )
+
+          print(output)
+          PY
+
+      - name: Upload CLI package
+        uses: actions/upload-artifact@v4
+        with:
+          name: gdmcp-${{ matrix.target }}
+          path: dist/gdmcp-${{ needs.prepare.outputs.version }}-${{ matrix.target }}.zip
+          if-no-files-found: error
+          retention-days: 7
+
+  package-plugin:
+    needs: prepare
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out release source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.source_sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Create plugin ZIP
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          python - <<'PY'
+          import os
+          import stat
+          import zipfile
+          from pathlib import Path
+
+          version = os.environ["VERSION"]
+          source = Path("addons/godot_mcp")
+          output = Path("dist") / f"godot-mcp-native-{version}.zip"
+
+          if not source.is_dir():
+              raise SystemExit(f"plugin directory was not found: {source}")
+
+          output.parent.mkdir(parents=True, exist_ok=True)
+          files = sorted(path for path in source.rglob("*") if path.is_file())
+          if not files:
+              raise SystemExit("plugin directory contains no files")
+
+          with zipfile.ZipFile(output, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+              for path in files:
+                  relative = path.relative_to(source)
+                  archive_name = (Path("addons/godot_mcp") / relative).as_posix()
+                  info = zipfile.ZipInfo(archive_name, date_time=(1980, 1, 1, 0, 0, 0))
+                  info.compress_type = zipfile.ZIP_DEFLATED
+                  info.create_system = 3
+                  mode = stat.S_IMODE(path.stat().st_mode) or 0o644
+                  info.external_attr = (mode & 0xFFFF) << 16
+                  archive.writestr(info, path.read_bytes())
+
+          print(output)
+          PY
+
+      - name: Upload plugin package
+        uses: actions/upload-artifact@v4
+        with:
+          name: godot-mcp-native
+          path: dist/godot-mcp-native-${{ needs.prepare.outputs.version }}.zip
+          if-no-files-found: error
+          retention-days: 7
+
+  release:
+    needs:
+      - prepare
+      - build-cli
+      - package-plugin
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      group: manual-gdmcp-release-${{ github.repository }}-${{ needs.prepare.outputs.tag }}
+      cancel-in-progress: false
+    steps:
+      - name: Check out release source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.source_sha }}
+          fetch-depth: 0
+
+      - name: Download all packages
+        uses: actions/download-artifact@v4
+        with:
+          path: release-assets
+          merge-multiple: true
+
+      - name: Validate complete asset set
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          python - <<'PY'
+          import os
+          from pathlib import Path
+
+          version = os.environ["VERSION"]
+          root = Path("release-assets")
+          expected = {
+              f"godot-mcp-native-{version}.zip",
+              f"gdmcp-{version}-x86_64-pc-windows-msvc.zip",
+              f"gdmcp-{version}-x86_64-unknown-linux-gnu.zip",
+              f"gdmcp-{version}-aarch64-unknown-linux-gnu.zip",
+              f"gdmcp-{version}-aarch64-apple-darwin.zip",
+              f"gdmcp-{version}-x86_64-apple-darwin.zip",
+          }
+          files = [path for path in root.rglob("*") if path.is_file()]
+          names = {path.name for path in files}
+
+          if names != expected or len(files) != len(expected):
+              print("Expected assets:")
+              for name in sorted(expected):
+                  print(f"  {name}")
+              print("Downloaded files:")
+              for path in sorted(files):
+                  print(f"  {path}")
+              raise SystemExit("release artifact set is incomplete or contains unexpected files")
+
+          for path in files:
+              if path.parent != root:
+                  raise SystemExit(f"asset is unexpectedly nested: {path}")
+              if path.stat().st_size == 0:
+                  raise SystemExit(f"asset is empty: {path}")
+          PY
+
+      - name: Create or update GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+          SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
+          PREPARED_TAG_EXISTS: ${{ needs.prepare.outputs.tag_exists }}
+          REPLACE_EXISTING_ASSETS: ${{ inputs.replace_existing_assets }}
+        run: |
+          set -euo pipefail
+
+          git fetch --force --tags origin
+          if git rev-parse -q --verify "refs/tags/${TAG}^{commit}" >/dev/null; then
+            actual_sha=$(git rev-parse "refs/tags/${TAG}^{commit}")
+            if [[ "$actual_sha" != "$SOURCE_SHA" ]]; then
+              echo "::error::Tag ${TAG} now points to ${actual_sha}, not the prepared source ${SOURCE_SHA}. The tag will not be moved."
+              exit 1
+            fi
+          else
+            if [[ "$PREPARED_TAG_EXISTS" == true ]]; then
+              echo "::error::Tag ${TAG} existed during preparation but no longer exists. Refusing to recreate it automatically."
+              exit 1
+            fi
+            git tag "$TAG" "$SOURCE_SHA"
+            git push origin "refs/tags/$TAG"
+          fi
+
+          mapfile -t assets < <(find release-assets -maxdepth 1 -type f -name '*.zip' -print | sort)
+          if [[ ${#assets[@]} -ne 6 ]]; then
+            echo "::error::Expected six validated release assets, found ${#assets[@]}."
+            exit 1
+          fi
+
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            if [[ "$REPLACE_EXISTING_ASSETS" != true ]]; then
+              echo "::error::Release ${TAG} was created after preparation. Re-run with replace_existing_assets enabled."
+              exit 1
+            fi
+            gh release upload "$TAG" "${assets[@]}" --clobber --repo "$GITHUB_REPOSITORY"
+            echo "Replaced workflow-managed assets on existing release ${TAG}; tag and Release metadata were unchanged."
+          else
+            gh release create "$TAG" "${assets[@]}" \
+              --repo "$GITHUB_REPOSITORY" \
+              --verify-tag \
+              --draft \
+              --title "$TAG" \
+              --generate-notes
+            echo "Created draft release ${TAG}."
+          fi

--- a/.github/workflows/manual-gdmcp-release.yml
+++ b/.github/workflows/manual-gdmcp-release.yml
@@ -28,6 +28,11 @@ jobs:
           ref: ${{ github.sha }}
           fetch-depth: 0
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
       - name: Resolve version, tag, and source commit
         id: prepare
         shell: bash
@@ -312,6 +317,11 @@ jobs:
         with:
           ref: ${{ needs.prepare.outputs.source_sha }}
           fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
 
       - name: Download all packages
         uses: actions/download-artifact@v4

--- a/docs/superpowers/plans/2026-07-27-manual-gdmcp-release-workflow.md
+++ b/docs/superpowers/plans/2026-07-27-manual-gdmcp-release-workflow.md
@@ -1,0 +1,141 @@
+# Manual gdmcp Release Workflow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a manual-only GitHub Actions workflow that reads the committed version, builds five CLI packages plus the plugin archive, and creates or selectively updates the matching GitHub Release without changing existing tags.
+
+**Architecture:** A prepare job resolves the version, tag, source commit, and release state. Independent matrix and plugin jobs build immutable workflow artifacts from the resolved commit. A final write-permission job validates the complete artifact set, creates a missing tag/release, or replaces only same-name assets on an existing release.
+
+**Tech Stack:** GitHub Actions YAML, GitHub CLI, Rust/Cargo, Python 3 standard library, actions/checkout, actions/upload-artifact, actions/download-artifact.
+
+## Global Constraints
+
+- The workflow trigger is only `workflow_dispatch`.
+- Do not modify `scripts/release.ps1` or any source version file.
+- Read the version from `cli/gdmcp/Cargo.toml` and validate `plugin.cfg` and `cli_release.json` match.
+- Existing tags are never moved or recreated.
+- Existing releases are unchanged unless `replace_existing_assets` is true.
+- Replacement changes only the six workflow-managed assets and preserves all Release metadata.
+- New Releases are drafts.
+- All CLI release archives are ZIP files with the existing seven-file packaging contract.
+- Build five targets: Windows x64, Linux x64, Linux arm64, macOS arm64, macOS x64.
+
+---
+
+### Task 1: Add the manual release workflow
+
+**Files:**
+- Create: `.github/workflows/manual-gdmcp-release.yml`
+
+**Interfaces:**
+- Consumes: committed version declarations and files under `cli/gdmcp/packaging/`.
+- Produces: workflow outputs `version`, `tag`, `source_sha`, `tag_exists`, and `release_exists`; six release ZIP files.
+
+- [ ] **Step 1: Define a manual-only trigger and safe permissions**
+
+Create a workflow with exactly one trigger:
+
+```yaml
+on:
+  workflow_dispatch:
+    inputs:
+      replace_existing_assets:
+        description: Replace workflow-managed assets when the release already exists
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+```
+
+Add `concurrency.cancel-in-progress: false` and a tag/version-specific group after the prepare output is available at job level where possible; also guard the release job with a repository/tag concurrency key.
+
+- [ ] **Step 2: Implement the prepare job**
+
+Checkout `${{ github.sha }}` with `fetch-depth: 0`, read the version from `cli/gdmcp/Cargo.toml`, validate strict `X.Y.Z` syntax, and compare it with:
+
+- `addons/godot_mcp/plugin.cfg`;
+- `addons/godot_mcp/cli_release.json`.
+
+Fetch tags and resolve `refs/tags/v<version>^{commit}` when present. If present, use that commit as `source_sha`; otherwise use `${{ github.sha }}`. Re-read and validate all three version declarations from `source_sha` using `git show` so an existing tag is validated against its own contents.
+
+Use `gh release view` to detect the Release. If it exists and the boolean input is false, fail before build jobs start. Export all prepare values through `$GITHUB_OUTPUT`.
+
+- [ ] **Step 3: Implement the five-target CLI matrix**
+
+Use the exact runner/target pairs from the design. Checkout `needs.prepare.outputs.source_sha`, install the stable Rust toolchain with the matrix target, and run:
+
+```bash
+cargo build --manifest-path cli/gdmcp/Cargo.toml --release --locked --target <target>
+```
+
+Use a Python standard-library packaging step to create `dist/gdmcp-<version>-<target>.zip`. The archive root must contain the executable, both installers, README, LICENSE, SHA256SUMS, and `release-manifest.json`. On Unix, preserve executable permission for `gdmcp` and `install.sh` in ZIP metadata.
+
+Upload each ZIP with `actions/upload-artifact` using a unique artifact name and `if-no-files-found: error`.
+
+- [ ] **Step 4: Implement the plugin package job**
+
+Checkout the same `source_sha`. Use Python `zipfile` to create `dist/godot-mcp-native-<version>.zip` with every file under `addons/godot_mcp/` stored under the `addons/godot_mcp/` archive prefix. Exclude no tracked plugin files. Upload it as a workflow artifact.
+
+- [ ] **Step 5: Implement the release job**
+
+Grant only this job `contents: write`. Download all artifacts into one directory with `merge-multiple: true`. Verify the exact six expected filenames exist and reject duplicate or unexpected ZIP names.
+
+If the tag was absent, create and push an annotated or lightweight tag at `source_sha` without force. Re-check that the remote tag resolves to `source_sha`.
+
+If the Release is absent, run `gh release create` with `--draft`, `--title v<version>`, `--target <source_sha>`, generated notes, and all six assets.
+
+If the Release exists, require the replacement input and run `gh release upload <tag> <six exact paths> --clobber`. Do not call `gh release edit`, delete the Release, move the tag, or upload wildcard paths.
+
+- [ ] **Step 6: Commit the workflow**
+
+```bash
+git add .github/workflows/manual-gdmcp-release.yml
+git commit -m "ci: add manual multi-platform release workflow"
+```
+
+### Task 2: Verify the workflow contract
+
+**Files:**
+- Test: `.github/workflows/manual-gdmcp-release.yml`
+
+**Interfaces:**
+- Consumes: the completed workflow file.
+- Produces: evidence that syntax and safety requirements are satisfied before PR creation.
+
+- [ ] **Step 1: Parse the YAML locally**
+
+Run a YAML parser against the workflow and confirm the top-level mapping loads without duplicate keys. Because YAML 1.1 parsers can coerce `on`, also inspect the raw text to ensure the trigger is written as a GitHub Actions `on:` key.
+
+- [ ] **Step 2: Run actionlint**
+
+Run:
+
+```bash
+actionlint .github/workflows/manual-gdmcp-release.yml
+```
+
+Expected: exit code 0 and no diagnostics.
+
+- [ ] **Step 3: Run static safety assertions**
+
+Assert the file:
+
+- contains `workflow_dispatch`;
+- contains no `push:`, `pull_request:`, or `schedule:` trigger;
+- defaults replacement to false;
+- contains all five targets and runner labels;
+- uses `cargo build` with `--locked`;
+- creates only ZIP release assets;
+- uses `--draft` for new releases;
+- uses `gh release upload` with `--clobber` only in the existing-release path;
+- contains no force tag update and no `gh release edit`.
+
+- [ ] **Step 4: Review the branch diff**
+
+Compare the feature branch with `main` and confirm `scripts/release.ps1` is unchanged and only the design, plan, and workflow files were added.
+
+- [ ] **Step 5: Open a draft pull request**
+
+Create a draft PR targeting `main`. Describe that the workflow itself cannot appear in the Actions manual-run UI until merged to the default branch, and that the first real multi-platform run remains a post-merge validation step.

--- a/docs/superpowers/specs/2026-07-27-manual-gdmcp-release-workflow-design.md
+++ b/docs/superpowers/specs/2026-07-27-manual-gdmcp-release-workflow-design.md
@@ -1,0 +1,136 @@
+# Manual gdmcp Release Workflow Design
+
+## Goal
+
+Add a GitHub Actions workflow that is started only through `workflow_dispatch`, reads the version already committed to the repository, builds release archives for all supported CLI targets, packages the Godot plugin, and creates or updates the matching GitHub Release without modifying `scripts/release.ps1` or any version file.
+
+## Scope
+
+The workflow will:
+
+- have no `push`, `pull_request`, `schedule`, or tag trigger;
+- read the version from `cli/gdmcp/Cargo.toml`;
+- verify that `addons/godot_mcp/plugin.cfg` and `addons/godot_mcp/cli_release.json` contain the same version;
+- derive the tag as `v<version>`;
+- build Windows x64, Linux x64, Linux arm64, macOS arm64, and macOS x64 packages;
+- create `godot-mcp-native-<version>.zip` with an `addons/godot_mcp/` root;
+- create a draft Release when the matching Release does not exist;
+- optionally replace only the workflow-managed assets when the matching Release already exists;
+- never move or recreate an existing tag;
+- leave an existing Release title, notes, draft/published state, and other manually uploaded assets unchanged.
+
+The workflow will not:
+
+- modify `scripts/release.ps1`;
+- bump versions, edit source files, commit, or push source changes;
+- publish a draft Release automatically;
+- run GUT or the local release preparation process;
+- move an existing tag to a new commit.
+
+## Manual Input
+
+`workflow_dispatch` exposes one boolean input:
+
+- `replace_existing_assets`, default `false`.
+
+The version is never entered manually. The operator chooses the branch or ref in the GitHub Actions UI, and the workflow reads the version from that selected revision.
+
+## Source Commit Resolution
+
+1. Checkout the manually selected revision with full history and tags.
+2. Read the candidate version from `cli/gdmcp/Cargo.toml` and derive `v<version>`.
+3. If the tag already exists, resolve its peeled commit and use that commit for every build and package job.
+4. If the tag does not exist, use the selected workflow commit.
+5. Re-check the version files from the resolved source commit.
+6. If an existing tag's source does not declare the same version as its tag, fail before building.
+
+This guarantees that replacement assets are rebuilt from the commit already identified by the existing tag.
+
+## Existing Tag and Release Rules
+
+### Tag absent, Release absent
+
+Build the selected commit. After every artifact is available, create `v<version>` at the selected commit and create a draft Release containing all assets.
+
+### Tag present, Release absent
+
+Build the commit referenced by the tag. Keep the tag unchanged and create a draft Release for it.
+
+### Tag present, Release present, replacement disabled
+
+Fail during the prepare job before matrix builds begin.
+
+### Tag present, Release present, replacement enabled
+
+Build the tag commit. Keep the existing tag and Release metadata unchanged. Replace only matching workflow-managed asset names.
+
+## Build Matrix
+
+| Runner | Rust target | Archive executable |
+|---|---|---|
+| `windows-latest` | `x86_64-pc-windows-msvc` | `gdmcp.exe` |
+| `ubuntu-24.04` | `x86_64-unknown-linux-gnu` | `gdmcp` |
+| `ubuntu-24.04-arm` | `aarch64-unknown-linux-gnu` | `gdmcp` |
+| `macos-latest` | `aarch64-apple-darwin` | `gdmcp` |
+| `macos-15-intel` | `x86_64-apple-darwin` | `gdmcp` |
+
+Each matrix job runs a locked release build and creates:
+
+`gdmcp-<version>-<target>.zip`
+
+Every CLI archive contains these files at its root:
+
+- `gdmcp` or `gdmcp.exe`;
+- `install.ps1`;
+- `install.sh`;
+- `README.md`;
+- `LICENSE`;
+- `SHA256SUMS`;
+- `release-manifest.json`.
+
+This preserves compatibility with the existing plugin downloader and packaging contract.
+
+## Plugin Archive
+
+A separate job packages the resolved source commit into:
+
+`godot-mcp-native-<version>.zip`
+
+The archive root contains:
+
+```text
+addons/
+└── godot_mcp/
+```
+
+## Release Update Safety
+
+The release job starts only after all five CLI packages and the plugin package have been uploaded as workflow artifacts. It first verifies that the exact six expected files are present.
+
+For a new release, it creates a draft release with `--target <resolved-source-sha>` and uploads all files.
+
+For an existing release with replacement enabled, it uploads the six exact files with overwrite behavior. GitHub CLI replaces assets with the same names; unrelated assets remain untouched. Because replacing an asset is not transactional, all local artifacts are validated before any upload begins.
+
+## Permissions and Concurrency
+
+- Default workflow permission: `contents: read`.
+- Only the final release job receives `contents: write`.
+- A concurrency group keyed by repository and tag prevents two manual runs from updating the same version simultaneously.
+- Automatic cancellation is disabled so a later run cannot interrupt an in-progress release update.
+
+## Validation
+
+Static validation covers:
+
+- the workflow has only `workflow_dispatch`;
+- the replacement input defaults to false;
+- all five target/runner combinations are present;
+- version consistency checks are present;
+- builds use `--locked`;
+- all archives use `.zip` names expected by `cli_release.json`;
+- existing tags are never force-updated;
+- existing releases fail early unless replacement is enabled;
+- new releases are drafts;
+- replacement affects same-name assets only.
+
+The workflow itself cannot be fully executed until it is present on the default branch. After merge, the first manual run should be performed with replacement disabled against a version that does not already have a Release, or against a temporary test version prepared through the normal local version process.


### PR DESCRIPTION
## 概述

新增一个**仅手动执行**的 gdmcp 多平台打包发布工作流，替代 PR #57 中基于 push / PR / tag 自动触发的方案。

## 行为

- 仅支持 `workflow_dispatch`
- 不修改 `scripts/release.ps1`，也不修改任何版本文件
- 从 `cli/gdmcp/Cargo.toml` 读取版本，并校验 `plugin.cfg`、`cli_release.json` 版本一致
- 如果 `v<version>` Tag 已存在，检出并构建该 Tag 指向的提交
- 如果 Tag 不存在，所有构建成功后在手动选择的提交上创建 Tag
- Release 不存在时创建 Draft Release
- Release 已存在时，默认拒绝执行；勾选 `replace_existing_assets` 后只覆盖同名的六个工作流资产
- 不移动已有 Tag，不修改已有 Release 的标题、正文、Draft/Published 状态或其他人工资产

## 构建目标

- Windows x64: `x86_64-pc-windows-msvc`
- Linux x64: `x86_64-unknown-linux-gnu`
- Linux arm64: `aarch64-unknown-linux-gnu`
- macOS arm64: `aarch64-apple-darwin`
- macOS x64: `x86_64-apple-darwin`

所有 CLI 产物统一为 ZIP，并包含可执行文件、安装脚本、README、LICENSE、SHA256SUMS 和 release manifest。另生成包含 `addons/godot_mcp/` 的插件 ZIP。

## 已完成验证

- 版本一致性解析逻辑模拟通过
- CLI ZIP 内容和 SHA-256 manifest 组装模拟通过
- 插件 ZIP 根目录结构模拟通过
- prepare / release Bash 片段通过 `bash -n`
- 分支差异确认未修改 `scripts/release.ps1`
- 工作流仅包含 `workflow_dispatch`，无 push、pull_request、schedule 或 tag 自动触发

## 合并后验证

GitHub 仅会在工作流位于默认分支后提供手动运行入口，因此五个平台的真实 Runner 构建和 Release 创建/替换流程需要在合并后进行首次手动验证。该 PR 在完成首次真实流程确认前保持 Draft。