### PR TITLE
fix: align manual release artifact names

### DIFF
--- a/.github/workflows/gdmcp-cli.yml
+++ b/.github/workflows/gdmcp-cli.yml
@@ -11,8 +11,10 @@ on:
       - "test/unit/native_mcp/**"
       - "test/integration/test_cli_api_flow.py"
       - "test/integration/test_gdmcp_packaging.py"
+      - "test/integration/test_manual_release_workflow.py"
       - "docs/current/gdmcp-cli-reference.md"
       - ".github/workflows/gdmcp-cli.yml"
+      - ".github/workflows/manual-gdmcp-release.yml"
   pull_request:
     paths:
       - "cli/gdmcp/**"
@@ -23,8 +25,10 @@ on:
       - "test/unit/native_mcp/**"
       - "test/integration/test_cli_api_flow.py"
       - "test/integration/test_gdmcp_packaging.py"
+      - "test/integration/test_manual_release_workflow.py"
       - "docs/current/gdmcp-cli-reference.md"
       - ".github/workflows/gdmcp-cli.yml"
+      - ".github/workflows/manual-gdmcp-release.yml"
 
 jobs:
   rust:
@@ -50,9 +54,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Compile integration test
-        run: python -m py_compile test/integration/test_cli_api_flow.py test/integration/test_gdmcp_packaging.py
+      - name: Compile integration tests
+        run: python -m py_compile test/integration/test_cli_api_flow.py test/integration/test_gdmcp_packaging.py test/integration/test_manual_release_workflow.py
       - name: Packaging contract tests
         run: python test/integration/test_gdmcp_packaging.py
+      - name: Manual release workflow contracts
+        run: python test/integration/test_manual_release_workflow.py
       - name: POSIX script syntax
         run: bash -n cli/gdmcp/scripts/install-dev.sh cli/gdmcp/scripts/package.sh cli/gdmcp/packaging/install.sh

--- a/.github/workflows/manual-gdmcp-release.yml
+++ b/.github/workflows/manual-gdmcp-release.yml
@@ -237,7 +237,7 @@ jobs:
       - name: Upload CLI package
         uses: actions/upload-artifact@v4
         with:
-          name: gdmcp-${{ matrix.target }}
+          name: gdmcp-${{ needs.prepare.outputs.version }}-${{ matrix.target }}
           path: dist/gdmcp-${{ needs.prepare.outputs.version }}-${{ matrix.target }}.zip
           if-no-files-found: error
           retention-days: 7
@@ -295,7 +295,7 @@ jobs:
       - name: Upload plugin package
         uses: actions/upload-artifact@v4
         with:
-          name: godot-mcp-native
+          name: godot-mcp-native-${{ needs.prepare.outputs.version }}
           path: dist/godot-mcp-native-${{ needs.prepare.outputs.version }}.zip
           if-no-files-found: error
           retention-days: 7

--- a/test/integration/test_manual_release_workflow.py
+++ b/test/integration/test_manual_release_workflow.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "manual-gdmcp-release.yml"
+
+
+class ManualReleaseWorkflowTests(unittest.TestCase):
+    def test_actions_artifact_names_include_release_version(self) -> None:
+        text = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn(
+            "name: gdmcp-${{ needs.prepare.outputs.version }}-${{ matrix.target }}",
+            text,
+        )
+        self.assertIn(
+            "name: godot-mcp-native-${{ needs.prepare.outputs.version }}",
+            text,
+        )
+
+    def test_uploaded_file_paths_match_installer_download_contract(self) -> None:
+        text = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn(
+            "path: dist/gdmcp-${{ needs.prepare.outputs.version }}-${{ matrix.target }}.zip",
+            text,
+        )
+        self.assertIn(
+            "path: dist/godot-mcp-native-${{ needs.prepare.outputs.version }}.zip",
+            text,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## 根因

手动发布工作流生成的 ZIP 文件名符合本地 `package.ps1` 和插件 `cli_release.json` 下载 URL，但 `actions/upload-artifact` 的 Artifact 名称遗漏了版本号：

- 旧：`gdmcp-x86_64-pc-windows-msvc`
- 新：`gdmcp-1.0.8-x86_64-pc-windows-msvc`

插件 Artifact 同样由 `godot-mcp-native` 改为 `godot-mcp-native-1.0.8`。

真正上传到 GitHub Release 的内部 ZIP 文件名不变，仍为：

- `gdmcp-<version>-<target>.zip`
- `godot-mcp-native-<version>.zip`

## 改动

- Artifact 显示名加入 `needs.prepare.outputs.version`
- 新增 `test_manual_release_workflow.py` 锁定 Artifact 名和实际 ZIP 路径契约
- 让 `gdmcp CLI` CI 在手动发布工作流或契约测试变化时执行

## 验证

修复前契约测试按预期失败；修复后 Actions run `30255091415` 全部通过：

- Manual release workflow contracts
- Packaging contract tests
- POSIX script syntax
- Rust fmt / clippy / test / release build
