### PR TITLE
fix: make CLI UI installer cross-platform

### DIFF
--- a/.github/workflows/gdmcp-cli.yml
+++ b/.github/workflows/gdmcp-cli.yml
@@ -74,3 +74,24 @@ jobs:
         run: python test/integration/test_cli_installer_contract.py
       - name: POSIX script syntax
         run: bash -n cli/gdmcp/scripts/install-dev.sh cli/gdmcp/scripts/package.sh cli/gdmcp/packaging/install.sh
+
+  godot-script-parse:
+    runs-on: ubuntu-latest
+    env:
+      GODOT_VERSION: "4.6.1"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download Godot
+        run: |
+          curl --fail --location --retry 3 \
+            "https://downloads.godotengine.org/?flavor=stable&platform=linux.64&slug=linux.x86_64.zip&version=${GODOT_VERSION}" \
+            --output /tmp/godot.zip
+          unzip -q /tmp/godot.zip -d /tmp/godot
+          chmod +x "/tmp/godot/Godot_v${GODOT_VERSION}-stable_linux.x86_64"
+      - name: Parse CLI installer script
+        run: |
+          "/tmp/godot/Godot_v${GODOT_VERSION}-stable_linux.x86_64" \
+            --headless \
+            --path . \
+            --script addons/godot_mcp/ui/mcp_cli_installer.gd \
+            --check-only

--- a/.github/workflows/gdmcp-cli.yml
+++ b/.github/workflows/gdmcp-cli.yml
@@ -4,6 +4,10 @@ on:
   push:
     paths:
       - "cli/gdmcp/**"
+      - "addons/godot_mcp/cli_release.json"
+      - "addons/godot_mcp/ui/mcp_cli_installer.gd"
+      - "addons/godot_mcp/ui/mcp_panel_native.gd"
+      - "addons/godot_mcp/translations/mcp_panel.csv"
       - "addons/godot_mcp/native_mcp/cli_*.gd"
       - "addons/godot_mcp/native_mcp/tool_*.gd"
       - "addons/godot_mcp/native_mcp/mcp_server_core*.gd"
@@ -12,12 +16,17 @@ on:
       - "test/integration/test_cli_api_flow.py"
       - "test/integration/test_gdmcp_packaging.py"
       - "test/integration/test_manual_release_workflow.py"
+      - "test/integration/test_cli_installer_contract.py"
       - "docs/current/gdmcp-cli-reference.md"
       - ".github/workflows/gdmcp-cli.yml"
       - ".github/workflows/manual-gdmcp-release.yml"
   pull_request:
     paths:
       - "cli/gdmcp/**"
+      - "addons/godot_mcp/cli_release.json"
+      - "addons/godot_mcp/ui/mcp_cli_installer.gd"
+      - "addons/godot_mcp/ui/mcp_panel_native.gd"
+      - "addons/godot_mcp/translations/mcp_panel.csv"
       - "addons/godot_mcp/native_mcp/cli_*.gd"
       - "addons/godot_mcp/native_mcp/tool_*.gd"
       - "addons/godot_mcp/native_mcp/mcp_server_core*.gd"
@@ -26,6 +35,7 @@ on:
       - "test/integration/test_cli_api_flow.py"
       - "test/integration/test_gdmcp_packaging.py"
       - "test/integration/test_manual_release_workflow.py"
+      - "test/integration/test_cli_installer_contract.py"
       - "docs/current/gdmcp-cli-reference.md"
       - ".github/workflows/gdmcp-cli.yml"
       - ".github/workflows/manual-gdmcp-release.yml"
@@ -55,10 +65,12 @@ jobs:
         with:
           python-version: "3.12"
       - name: Compile integration tests
-        run: python -m py_compile test/integration/test_cli_api_flow.py test/integration/test_gdmcp_packaging.py test/integration/test_manual_release_workflow.py
+        run: python -m py_compile test/integration/test_cli_api_flow.py test/integration/test_gdmcp_packaging.py test/integration/test_manual_release_workflow.py test/integration/test_cli_installer_contract.py
       - name: Packaging contract tests
         run: python test/integration/test_gdmcp_packaging.py
       - name: Manual release workflow contracts
         run: python test/integration/test_manual_release_workflow.py
+      - name: CLI installer contracts
+        run: python test/integration/test_cli_installer_contract.py
       - name: POSIX script syntax
         run: bash -n cli/gdmcp/scripts/install-dev.sh cli/gdmcp/scripts/package.sh cli/gdmcp/packaging/install.sh

--- a/.github/workflows/gdmcp-cli.yml
+++ b/.github/workflows/gdmcp-cli.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Download Godot
         run: |
           curl --fail --location --retry 3 \
-            "https://downloads.godotengine.org/?flavor=stable&platform=linux.64&slug=linux.x86_64.zip&version=${GODOT_VERSION}" \
+            "https://github.com/godotengine/godot-builds/releases/download/${GODOT_VERSION}-stable/Godot_v${GODOT_VERSION}-stable_linux.x86_64.zip" \
             --output /tmp/godot.zip
           unzip -q /tmp/godot.zip -d /tmp/godot
           chmod +x "/tmp/godot/Godot_v${GODOT_VERSION}-stable_linux.x86_64"

--- a/addons/godot_mcp/cli_release.json
+++ b/addons/godot_mcp/cli_release.json
@@ -11,6 +11,7 @@
   "targets": {
     "x86_64-pc-windows-msvc": "gdmcp.exe",
     "x86_64-unknown-linux-gnu": "gdmcp",
+    "aarch64-unknown-linux-gnu": "gdmcp",
     "aarch64-apple-darwin": "gdmcp",
     "x86_64-apple-darwin": "gdmcp"
   }

--- a/addons/godot_mcp/ui/mcp_cli_installer.gd
+++ b/addons/godot_mcp/ui/mcp_cli_installer.gd
@@ -25,115 +25,314 @@ func _load_config() -> void:
 	file.close()
 	var json: JSON = JSON.new()
 	var err: int = json.parse(text)
-	if err != OK:
+	if err != OK or typeof(json.data) != TYPE_DICTIONARY:
 		push_warning("Failed to parse CLI release config")
 		return
 	_release_config = json.data
 
 func cli_version() -> String:
-	return _release_config.get("version", "0.0.0")
+	return str(_release_config.get("version", "0.0.0"))
+
+static func resolve_platform_target(os_name: String, architecture: String) -> String:
+	match os_name:
+		"Windows":
+			if architecture == "x86_64":
+				return "x86_64-pc-windows-msvc"
+		"Linux":
+			if architecture == "arm64":
+				return "aarch64-unknown-linux-gnu"
+			if architecture == "x86_64":
+				return "x86_64-unknown-linux-gnu"
+		"macOS":
+			if architecture == "arm64":
+				return "aarch64-apple-darwin"
+			if architecture == "x86_64":
+				return "x86_64-apple-darwin"
+	return ""
 
 func platform_target() -> String:
-	match OS.get_name():
-		"Windows":
-			return "x86_64-pc-windows-msvc"
-		"macOS":
-			var arch: String = OS.get_processor_name().to_lower()
-			if "arm" in arch:
-				return "aarch64-apple-darwin"
-			return "x86_64-apple-darwin"
-		_:
-			return "x86_64-unknown-linux-gnu"
+	return resolve_platform_target(OS.get_name(), Engine.get_architecture_name())
+
+func is_platform_supported() -> bool:
+	var target: String = platform_target()
+	if target.is_empty():
+		return false
+	var targets: Dictionary = _release_config.get("targets", {})
+	return targets.has(target)
 
 func platform_exe_name() -> String:
-	var targets: Dictionary = _release_config.get("targets", {})
 	var target: String = platform_target()
-	return targets.get(target, "gdmcp.exe" if OS.get_name() == "Windows" else "gdmcp")
+	if target.is_empty():
+		return ""
+	var targets: Dictionary = _release_config.get("targets", {})
+	return str(targets.get(target, ""))
 
 func detect_state(project_path: String) -> Dictionary:
 	var install_dir: String = project_path.path_join(".gdmcp/bin")
-	var exe_path: String = install_dir.path_join(platform_exe_name())
-	var installed: bool = FileAccess.file_exists(exe_path)
+	var exe_name: String = platform_exe_name()
+	var exe_path: String = install_dir.path_join(exe_name) if not exe_name.is_empty() else ""
+	var installed: bool = not exe_path.is_empty() and FileAccess.file_exists(exe_path)
 	return {
 		"installed": installed,
+		"supported": is_platform_supported(),
 		"exe_path": exe_path,
 		"install_dir": install_dir,
 		"version": cli_version(),
+		"target": platform_target(),
 	}
 
 func download_url(source: String) -> String:
+	var target: String = platform_target()
+	if target.is_empty():
+		return ""
 	if source == "github":
-		var tmpl: String = _release_config.get("github", {}).get("url_template", "")
-		return tmpl.replace("{version}", cli_version()).replace("{target}", platform_target())
+		var tmpl: String = str(_release_config.get("github", {}).get("url_template", ""))
+		return tmpl.replace("{version}", cli_version()).replace("{target}", target)
 	var quark: Dictionary = _release_config.get("quark", {})
-	return quark.get("direct_download", "")
+	return str(quark.get("direct_download", ""))
 
 func download_page_url() -> String:
-	return _release_config.get("quark", {}).get("page_url", "")
+	return str(_release_config.get("quark", {}).get("page_url", ""))
 
 func install_from(source: String, install_dir: String, on_complete: Callable) -> void:
+	var target: String = platform_target()
+	var exe_name: String = platform_exe_name()
+	if target.is_empty() or exe_name.is_empty() or not is_platform_supported():
+		on_complete.call(false, "Unsupported platform: %s / %s" % [OS.get_name(), Engine.get_architecture_name()])
+		return
+
 	var url: String = download_url(source)
 	if url.is_empty():
-		# Quark can't direct-download; open browser
 		if source == "quark":
 			OS.shell_open(download_page_url())
-			on_complete.call(false, "Quark cloud drive does not support direct download. Browser opened — download manually and place %s in:\n%s" % [platform_exe_name(), install_dir])
+			on_complete.call(false, "Quark cloud drive does not support direct download. Browser opened — download manually and place %s in:\n%s" % [exe_name, install_dir])
 		else:
 			on_complete.call(false, "Download URL not configured for source: %s" % source)
 		return
 
+	if _scene_tree == null:
+		on_complete.call(false, "SceneTree is not available for CLI download")
+		return
 	if _http == null:
 		_http = HTTPRequest.new()
 		_scene_tree.root.add_child(_http)
-	else:
-		if _http.request_completed.is_connected(_on_download_completed):
-			_http.request_completed.disconnect(_on_download_completed)
-	_http.request_completed.connect(_on_download_completed.bind(on_complete, install_dir), CONNECT_ONE_SHOT)
+	elif _http.request_completed.is_connected(_on_download_completed):
+		_http.request_completed.disconnect(_on_download_completed)
+	_http.request_completed.connect(
+		_on_download_completed.bind(on_complete, install_dir, target, exe_name),
+		CONNECT_ONE_SHOT
+	)
 	var error: int = _http.request(url)
 	if error != OK:
 		on_complete.call(false, "Download request failed: error code %d" % error)
 
-func _on_download_completed(result: int, response_code: int, _headers: PackedStringArray, body: PackedByteArray, on_complete: Callable, install_dir: String) -> void:
+func _on_download_completed(
+	result: int,
+	response_code: int,
+	_headers: PackedStringArray,
+	body: PackedByteArray,
+	on_complete: Callable,
+	install_dir: String,
+	target: String,
+	exe_name: String
+) -> void:
 	if result != HTTPRequest.RESULT_SUCCESS or response_code != 200:
 		on_complete.call(false, "Download failed (HTTP %d). Try the alternate download source." % response_code)
 		return
-
-	# Save zip to temp file, then extract with ZIPReader
-	var tmp_zip: String = install_dir.path_join("_gdmcp_download.zip")
-	DirAccess.make_dir_recursive_absolute(install_dir)
-	var tmp_file: FileAccess = FileAccess.open(tmp_zip, FileAccess.WRITE)
-	if tmp_file == null:
-		on_complete.call(false, "Cannot write temp file to %s" % tmp_zip)
-		return
-	tmp_file.store_buffer(body)
-	tmp_file.close()
-
-	var zip_reader: ZIPReader = ZIPReader.new()
-	var err: int = zip_reader.open(tmp_zip)
-	if err != OK:
-		DirAccess.remove_absolute(tmp_zip)
-		on_complete.call(false, "Failed to open downloaded archive")
+	if body.is_empty():
+		on_complete.call(false, "Downloaded archive is empty")
 		return
 
-	var exe_name: String = platform_exe_name()
-	var exe_data: PackedByteArray = zip_reader.read_file(exe_name)
-	zip_reader.close()
-	DirAccess.remove_absolute(tmp_zip)
-
-	if exe_data.is_empty():
-		on_complete.call(false, "Archive does not contain %s" % exe_name)
+	var temp_root: String = ProjectSettings.globalize_path("user://").path_join(
+		"gdmcp_install_%d" % Time.get_ticks_usec()
+	)
+	var create_error: int = DirAccess.make_dir_recursive_absolute(temp_root)
+	if create_error != OK:
+		on_complete.call(false, "Cannot create temporary install directory: %s" % temp_root)
 		return
 
-	DirAccess.make_dir_recursive_absolute(install_dir)
+	var zip_path: String = temp_root.path_join("gdmcp.zip")
+	var archive_root: String = temp_root.path_join("archive")
+	DirAccess.make_dir_recursive_absolute(archive_root)
+	var zip_file: FileAccess = FileAccess.open(zip_path, FileAccess.WRITE)
+	if zip_file == null:
+		_remove_tree(temp_root)
+		on_complete.call(false, "Cannot write temporary archive: %s" % zip_path)
+		return
+	zip_file.store_buffer(body)
+	zip_file.close()
+
+	var extract_error: String = _extract_archive(zip_path, archive_root)
+	if not extract_error.is_empty():
+		_remove_tree(temp_root)
+		on_complete.call(false, extract_error)
+		return
+
+	var manifest_error: String = _validate_manifest(archive_root, target, exe_name)
+	if not manifest_error.is_empty():
+		_remove_tree(temp_root)
+		on_complete.call(false, manifest_error)
+		return
+
+	var install_result: Dictionary = _run_packaged_installer(archive_root, install_dir, target)
+	_remove_tree(temp_root)
+	if not bool(install_result.get("success", false)):
+		on_complete.call(false, str(install_result.get("message", "CLI installer failed")))
+		return
+
 	var exe_path: String = install_dir.path_join(exe_name)
-	var file: FileAccess = FileAccess.open(exe_path, FileAccess.WRITE)
-	if file == null:
-		on_complete.call(false, "Cannot write to %s" % exe_path)
+	if not FileAccess.file_exists(exe_path):
+		on_complete.call(false, "Installer completed but executable was not created: %s" % exe_path)
 		return
-	file.store_buffer(exe_data)
-	file.close()
 
-	if OS.get_name() != "Windows":
-		OS.execute("chmod", ["+x", exe_path])
+	var version_output: Array = []
+	var version_exit_code: int = OS.execute(exe_path, PackedStringArray(["--version"]), version_output, true)
+	var version_text: String = _join_output(version_output)
+	if version_exit_code != 0 or not version_text.contains(cli_version()):
+		DirAccess.remove_absolute(exe_path)
+		on_complete.call(false, "Installed CLI failed version verification (exit %d):\n%s" % [version_exit_code, version_text])
+		return
 
-	on_complete.call(true, "CLI installed to %s" % exe_path)
+	var installer_message: String = str(install_result.get("message", "")).strip_edges()
+	var message: String = "CLI %s installed to %s" % [version_text.strip_edges(), exe_path]
+	if not installer_message.is_empty():
+		message += "\n" + installer_message
+	on_complete.call(true, message)
+
+func _extract_archive(zip_path: String, archive_root: String) -> String:
+	var reader: ZIPReader = ZIPReader.new()
+	var open_error: int = reader.open(zip_path)
+	if open_error != OK:
+		return "Failed to open downloaded ZIP archive"
+
+	for entry in reader.get_files():
+		var normalized: String = entry.replace("\\", "/")
+		if normalized.is_empty():
+			continue
+		var components: PackedStringArray = normalized.split("/", false)
+		if normalized.begins_with("/") or normalized.contains(":") or components.has(".."):
+			reader.close()
+			return "Archive contains an unsafe path: %s" % entry
+		var destination: String = archive_root.path_join(normalized)
+		if normalized.ends_with("/"):
+			var dir_error: int = DirAccess.make_dir_recursive_absolute(destination)
+			if dir_error != OK:
+				reader.close()
+				return "Cannot create archive directory: %s" % destination
+			continue
+		var parent_error: int = DirAccess.make_dir_recursive_absolute(destination.get_base_dir())
+		if parent_error != OK:
+			reader.close()
+			return "Cannot create archive directory: %s" % destination.get_base_dir()
+		var output: FileAccess = FileAccess.open(destination, FileAccess.WRITE)
+		if output == null:
+			reader.close()
+			return "Cannot extract archive file: %s" % destination
+		output.store_buffer(reader.read_file(entry))
+		output.close()
+	reader.close()
+	return ""
+
+func _validate_manifest(archive_root: String, target: String, exe_name: String) -> String:
+	var manifest_path: String = archive_root.path_join("release-manifest.json")
+	var checksums_path: String = archive_root.path_join("SHA256SUMS")
+	var script_name: String = "install.ps1" if OS.get_name() == "Windows" else "install.sh"
+	var required_paths: PackedStringArray = PackedStringArray([
+		manifest_path,
+		checksums_path,
+		archive_root.path_join(script_name),
+		archive_root.path_join(exe_name),
+	])
+	for required_path in required_paths:
+		if not FileAccess.file_exists(required_path):
+			return "Archive is missing required file: %s" % required_path.get_file()
+
+	var manifest_file: FileAccess = FileAccess.open(manifest_path, FileAccess.READ)
+	if manifest_file == null:
+		return "Cannot read release manifest"
+	var manifest_text: String = manifest_file.get_as_text()
+	manifest_file.close()
+	var json: JSON = JSON.new()
+	var parse_error: int = json.parse(manifest_text)
+	if parse_error != OK or typeof(json.data) != TYPE_DICTIONARY:
+		return "Release manifest is not valid JSON"
+	var manifest: Dictionary = json.data
+	if int(manifest.get("schema_version", 0)) != 1:
+		return "Unsupported release manifest schema"
+	if str(manifest.get("package", "")) != "gdmcp":
+		return "Release manifest package is not gdmcp"
+	if str(manifest.get("version", "")) != cli_version():
+		return "Release manifest version does not match requested version"
+	if str(manifest.get("target", "")) != target:
+		return "Release manifest target does not match this platform"
+	if str(manifest.get("executable", "")) != exe_name:
+		return "Release manifest executable does not match this platform"
+	return ""
+
+func _run_packaged_installer(archive_root: String, install_dir: String, target: String) -> Dictionary:
+	var output: Array = []
+	var exit_code: int = -1
+	if OS.get_name() == "Windows":
+		var script_path: String = archive_root.path_join("install.ps1")
+		exit_code = OS.execute(
+			"powershell.exe",
+			PackedStringArray([
+				"-NoProfile",
+				"-NonInteractive",
+				"-ExecutionPolicy",
+				"Bypass",
+				"-File",
+				script_path,
+				"-InstallRoot",
+				install_dir,
+				"-ExpectedVersion",
+				cli_version(),
+				"-ExpectedTarget",
+				target,
+			]),
+			output,
+			true
+		)
+	else:
+		var script_path: String = archive_root.path_join("install.sh")
+		exit_code = OS.execute(
+			"/bin/sh",
+			PackedStringArray([
+				script_path,
+				"--install-root",
+				install_dir,
+				"--expected-version",
+				cli_version(),
+				"--expected-target",
+				target,
+			]),
+			output,
+			true
+		)
+	var output_text: String = _join_output(output)
+	if exit_code != 0:
+		return {
+			"success": false,
+			"message": "Packaged installer failed (exit %d):\n%s" % [exit_code, output_text],
+		}
+	return {"success": true, "message": output_text}
+
+func _join_output(output: Array) -> String:
+	var lines: PackedStringArray = PackedStringArray()
+	for item in output:
+		var text: String = str(item).strip_edges()
+		if not text.is_empty():
+			lines.append(text)
+	return "\n".join(lines)
+
+func _remove_tree(path: String) -> void:
+	if not DirAccess.dir_exists_absolute(path):
+		return
+	var dir: DirAccess = DirAccess.open(path)
+	if dir == null:
+		return
+	for file_name in dir.get_files():
+		DirAccess.remove_absolute(path.path_join(file_name))
+	for directory_name in dir.get_directories():
+		_remove_tree(path.path_join(directory_name))
+	DirAccess.remove_absolute(path)

--- a/addons/godot_mcp/ui/mcp_cli_installer.gd
+++ b/addons/godot_mcp/ui/mcp_cli_installer.gd
@@ -224,12 +224,12 @@ func _extract_archive(zip_path: String, archive_root: String) -> String:
 		if parent_error != OK:
 			reader.close()
 			return "Cannot create archive directory: %s" % destination.get_base_dir()
-		var output: FileAccess = FileAccess.open(destination, FileAccess.WRITE)
-		if output == null:
+		var extracted_file: FileAccess = FileAccess.open(destination, FileAccess.WRITE)
+		if extracted_file == null:
 			reader.close()
 			return "Cannot extract archive file: %s" % destination
-		output.store_buffer(reader.read_file(entry))
-		output.close()
+		extracted_file.store_buffer(reader.read_file(entry))
+		extracted_file.close()
 	reader.close()
 	return ""
 
@@ -272,8 +272,9 @@ func _validate_manifest(archive_root: String, target: String, exe_name: String) 
 func _run_packaged_installer(archive_root: String, install_dir: String, target: String) -> Dictionary:
 	var output: Array = []
 	var exit_code: int = -1
+	var script_path: String
 	if OS.get_name() == "Windows":
-		var script_path: String = archive_root.path_join("install.ps1")
+		script_path = archive_root.path_join("install.ps1")
 		exit_code = OS.execute(
 			"powershell.exe",
 			PackedStringArray([
@@ -294,7 +295,7 @@ func _run_packaged_installer(archive_root: String, install_dir: String, target: 
 			true
 		)
 	else:
-		var script_path: String = archive_root.path_join("install.sh")
+		script_path = archive_root.path_join("install.sh")
 		exit_code = OS.execute(
 			"/bin/sh",
 			PackedStringArray([

--- a/cli/gdmcp/packaging/install.ps1
+++ b/cli/gdmcp/packaging/install.ps1
@@ -1,6 +1,8 @@
 [CmdletBinding()]
 param(
     [string]$InstallRoot,
+    [string]$ExpectedVersion,
+    [string]$ExpectedTarget,
     [switch]$AddPath,
     [switch]$Uninstall,
     [switch]$DryRun
@@ -24,10 +26,28 @@ if (-not (Test-Path -LiteralPath $checksumsPath)) {
 }
 
 $manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
+$schemaVersion = [int]$manifest.schema_version
+$packageName = [string]$manifest.package
+$manifestVersion = [string]$manifest.version
+$manifestTarget = [string]$manifest.target
 $executableName = [string]$manifest.executable
+
+if ($schemaVersion -ne 1) {
+    throw "Unsupported release manifest schema: $schemaVersion"
+}
+if ($packageName -ne "gdmcp") {
+    throw "Release manifest package is not gdmcp: $packageName"
+}
+if (-not [string]::IsNullOrWhiteSpace($ExpectedVersion) -and $manifestVersion -ne $ExpectedVersion) {
+    throw "Release manifest version mismatch: expected $ExpectedVersion but found $manifestVersion"
+}
+if (-not [string]::IsNullOrWhiteSpace($ExpectedTarget) -and $manifestTarget -ne $ExpectedTarget) {
+    throw "Release manifest target mismatch: expected $ExpectedTarget but found $manifestTarget"
+}
 if ([string]::IsNullOrWhiteSpace($executableName) -or $executableName -match '[\\/]') {
     throw "Release manifest contains an invalid executable name."
 }
+
 $source = Join-Path $ArchiveRoot $executableName
 $destination = Join-Path $InstallRoot $executableName
 

--- a/cli/gdmcp/packaging/install.sh
+++ b/cli/gdmcp/packaging/install.sh
@@ -43,11 +43,16 @@ checksums_path=$archive_root/SHA256SUMS
 [ -f "$manifest_path" ] || { printf 'Release manifest not found: %s\n' "$manifest_path" >&2; exit 1; }
 [ -f "$checksums_path" ] || { printf 'Checksum file not found: %s\n' "$checksums_path" >&2; exit 1; }
 
-schema_version=$(awk -F ':' '/"schema_version"[[:space:]]*:/ { value=$2; gsub(/[^0-9]/, "", value); print value; exit }' "$manifest_path")
-package_name=$(awk -F '"' '/"package"[[:space:]]*:/ { print $4; exit }' "$manifest_path")
-manifest_version=$(awk -F '"' '/"version"[[:space:]]*:/ { print $4; exit }' "$manifest_path")
-manifest_target=$(awk -F '"' '/"target"[[:space:]]*:/ { print $4; exit }' "$manifest_path")
-executable=$(awk -F '"' '/"executable"[[:space:]]*:/ { print $4; exit }' "$manifest_path")
+json_string_value() {
+    key=$1
+    sed -n 's/.*"'"$key"'"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$manifest_path" | head -n 1
+}
+
+schema_version=$(sed -n 's/.*"schema_version"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$manifest_path" | head -n 1)
+package_name=$(json_string_value package)
+manifest_version=$(json_string_value version)
+manifest_target=$(json_string_value target)
+executable=$(json_string_value executable)
 
 [ "$schema_version" = "1" ] || { printf 'Unsupported release manifest schema: %s\n' "$schema_version" >&2; exit 1; }
 [ "$package_name" = "gdmcp" ] || { printf 'Release manifest package is not gdmcp: %s\n' "$package_name" >&2; exit 1; }

--- a/cli/gdmcp/packaging/install.sh
+++ b/cli/gdmcp/packaging/install.sh
@@ -3,12 +3,14 @@ set -eu
 
 archive_root=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 install_root=${GDMCP_INSTALL_ROOT:-"$HOME/.local/gdmcp/bin"}
+expected_version=
+expected_target=
 add_path=0
 uninstall=0
 dry_run=0
 
 usage() {
-    printf '%s\n' "Usage: install.sh [--install-root DIR] [--add-path] [--uninstall] [--dry-run]"
+    printf '%s\n' "Usage: install.sh [--install-root DIR] [--expected-version VERSION] [--expected-target TARGET] [--add-path] [--uninstall] [--dry-run]"
 }
 
 while [ "$#" -gt 0 ]; do
@@ -16,6 +18,16 @@ while [ "$#" -gt 0 ]; do
         --install-root)
             [ "$#" -ge 2 ] || { usage >&2; exit 2; }
             install_root=$2
+            shift 2
+            ;;
+        --expected-version)
+            [ "$#" -ge 2 ] || { usage >&2; exit 2; }
+            expected_version=$2
+            shift 2
+            ;;
+        --expected-target)
+            [ "$#" -ge 2 ] || { usage >&2; exit 2; }
+            expected_target=$2
             shift 2
             ;;
         --add-path) add_path=1; shift ;;
@@ -31,7 +43,22 @@ checksums_path=$archive_root/SHA256SUMS
 [ -f "$manifest_path" ] || { printf 'Release manifest not found: %s\n' "$manifest_path" >&2; exit 1; }
 [ -f "$checksums_path" ] || { printf 'Checksum file not found: %s\n' "$checksums_path" >&2; exit 1; }
 
+schema_version=$(awk -F ':' '/"schema_version"[[:space:]]*:/ { value=$2; gsub(/[^0-9]/, "", value); print value; exit }' "$manifest_path")
+package_name=$(awk -F '"' '/"package"[[:space:]]*:/ { print $4; exit }' "$manifest_path")
+manifest_version=$(awk -F '"' '/"version"[[:space:]]*:/ { print $4; exit }' "$manifest_path")
+manifest_target=$(awk -F '"' '/"target"[[:space:]]*:/ { print $4; exit }' "$manifest_path")
 executable=$(awk -F '"' '/"executable"[[:space:]]*:/ { print $4; exit }' "$manifest_path")
+
+[ "$schema_version" = "1" ] || { printf 'Unsupported release manifest schema: %s\n' "$schema_version" >&2; exit 1; }
+[ "$package_name" = "gdmcp" ] || { printf 'Release manifest package is not gdmcp: %s\n' "$package_name" >&2; exit 1; }
+if [ -n "$expected_version" ] && [ "$manifest_version" != "$expected_version" ]; then
+    printf 'Release manifest version mismatch: expected %s but found %s\n' "$expected_version" "$manifest_version" >&2
+    exit 1
+fi
+if [ -n "$expected_target" ] && [ "$manifest_target" != "$expected_target" ]; then
+    printf 'Release manifest target mismatch: expected %s but found %s\n' "$expected_target" "$manifest_target" >&2
+    exit 1
+fi
 [ -n "$executable" ] || { printf 'Manifest executable is missing.\n' >&2; exit 1; }
 case "$executable" in */*|*\\*) printf 'Manifest executable is invalid.\n' >&2; exit 1 ;; esac
 

--- a/test/integration/test_cli_installer_contract.py
+++ b/test/integration/test_cli_installer_contract.py
@@ -56,8 +56,9 @@ class CliInstallerContractTests(unittest.TestCase):
             install_root = Path(temp_dir) / "installed"
             archive_root.mkdir()
             executable = archive_root / "gdmcp"
-            executable.write_bytes(b"#!/bin/sh\necho gdmcp 1.2.3\n")
-            digest = hashlib.sha256(executable.read_bytes()).hexdigest()
+            original_bytes = b"#!/bin/sh\necho gdmcp 1.2.3\n"
+            executable.write_bytes(original_bytes)
+            digest = hashlib.sha256(original_bytes).hexdigest()
             (archive_root / "SHA256SUMS").write_text(
                 f"{digest}  gdmcp\n",
                 encoding="utf-8",
@@ -95,7 +96,7 @@ class CliInstallerContractTests(unittest.TestCase):
 
             self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
             installed = install_root / "gdmcp"
-            self.assertEqual(installed.read_bytes(), executable.read_bytes())
+            self.assertEqual(installed.read_bytes(), original_bytes)
             self.assertTrue(os.access(installed, os.X_OK))
 
             mismatch_root = Path(temp_dir) / "mismatch"
@@ -117,6 +118,27 @@ class CliInstallerContractTests(unittest.TestCase):
             self.assertNotEqual(mismatch.returncode, 0)
             self.assertIn("target mismatch", (mismatch.stdout + mismatch.stderr).lower())
             self.assertFalse((mismatch_root / "gdmcp").exists())
+
+            executable.write_bytes(original_bytes + b"# tampered\n")
+            tampered_root = Path(temp_dir) / "tampered"
+            tampered = subprocess.run(
+                [
+                    "/bin/sh",
+                    str(installer),
+                    "--install-root",
+                    str(tampered_root),
+                    "--expected-version",
+                    "1.2.3",
+                    "--expected-target",
+                    "aarch64-unknown-linux-gnu",
+                ],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertNotEqual(tampered.returncode, 0)
+            self.assertIn("sha-256 verification failed", (tampered.stdout + tampered.stderr).lower())
+            self.assertFalse((tampered_root / "gdmcp").exists())
 
 
 if __name__ == "__main__":

--- a/test/integration/test_cli_installer_contract.py
+++ b/test/integration/test_cli_installer_contract.py
@@ -1,4 +1,8 @@
+import hashlib
 import json
+import os
+import subprocess
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -30,6 +34,7 @@ class CliInstallerContractTests(unittest.TestCase):
         self.assertIn("ExpectedVersion", installer)
         self.assertIn("expected-version", installer)
         self.assertIn("exit_code", installer)
+        self.assertIn('PackedStringArray(["--version"])', installer)
 
     def test_packaged_installers_validate_expected_manifest_identity(self) -> None:
         powershell = POWERSHELL_INSTALLER_PATH.read_text(encoding="utf-8")
@@ -37,10 +42,81 @@ class CliInstallerContractTests(unittest.TestCase):
 
         self.assertIn("ExpectedVersion", powershell)
         self.assertIn("ExpectedTarget", powershell)
-        self.assertIn('package', powershell)
+        self.assertIn("schema_version", powershell)
+        self.assertIn("package", powershell)
         self.assertIn("--expected-version", posix)
         self.assertIn("--expected-target", posix)
-        self.assertIn('package', posix)
+        self.assertIn("schema_version", posix)
+        self.assertIn("package", posix)
+
+    @unittest.skipIf(os.name == "nt", "POSIX installer test requires /bin/sh")
+    def test_posix_installer_verifies_identity_checksum_and_permissions(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            archive_root = Path(temp_dir) / "archive"
+            install_root = Path(temp_dir) / "installed"
+            archive_root.mkdir()
+            executable = archive_root / "gdmcp"
+            executable.write_bytes(b"#!/bin/sh\necho gdmcp 1.2.3\n")
+            digest = hashlib.sha256(executable.read_bytes()).hexdigest()
+            (archive_root / "SHA256SUMS").write_text(
+                f"{digest}  gdmcp\n",
+                encoding="utf-8",
+            )
+            (archive_root / "release-manifest.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "package": "gdmcp",
+                        "version": "1.2.3",
+                        "target": "aarch64-unknown-linux-gnu",
+                        "executable": "gdmcp",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            installer = archive_root / "install.sh"
+            installer.write_bytes(POSIX_INSTALLER_PATH.read_bytes())
+
+            result = subprocess.run(
+                [
+                    "/bin/sh",
+                    str(installer),
+                    "--install-root",
+                    str(install_root),
+                    "--expected-version",
+                    "1.2.3",
+                    "--expected-target",
+                    "aarch64-unknown-linux-gnu",
+                ],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            installed = install_root / "gdmcp"
+            self.assertEqual(installed.read_bytes(), executable.read_bytes())
+            self.assertTrue(os.access(installed, os.X_OK))
+
+            mismatch_root = Path(temp_dir) / "mismatch"
+            mismatch = subprocess.run(
+                [
+                    "/bin/sh",
+                    str(installer),
+                    "--install-root",
+                    str(mismatch_root),
+                    "--expected-version",
+                    "1.2.3",
+                    "--expected-target",
+                    "x86_64-unknown-linux-gnu",
+                ],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertNotEqual(mismatch.returncode, 0)
+            self.assertIn("target mismatch", (mismatch.stdout + mismatch.stderr).lower())
+            self.assertFalse((mismatch_root / "gdmcp").exists())
 
 
 if __name__ == "__main__":

--- a/test/integration/test_cli_installer_contract.py
+++ b/test/integration/test_cli_installer_contract.py
@@ -15,9 +15,18 @@ POSIX_INSTALLER_PATH = REPO_ROOT / "cli" / "gdmcp" / "packaging" / "install.sh"
 
 
 class CliInstallerContractTests(unittest.TestCase):
-    def test_supported_release_targets_include_linux_arm64(self) -> None:
+    def test_supported_release_target_matrix(self) -> None:
         config = json.loads(RELEASE_CONFIG_PATH.read_text(encoding="utf-8"))
-        self.assertEqual(config["targets"]["aarch64-unknown-linux-gnu"], "gdmcp")
+        self.assertEqual(
+            config["targets"],
+            {
+                "x86_64-pc-windows-msvc": "gdmcp.exe",
+                "x86_64-unknown-linux-gnu": "gdmcp",
+                "aarch64-unknown-linux-gnu": "gdmcp",
+                "aarch64-apple-darwin": "gdmcp",
+                "x86_64-apple-darwin": "gdmcp",
+            },
+        )
 
     def test_ui_uses_godot_architecture_and_platform_install_scripts(self) -> None:
         installer = INSTALLER_PATH.read_text(encoding="utf-8")

--- a/test/integration/test_cli_installer_contract.py
+++ b/test/integration/test_cli_installer_contract.py
@@ -1,0 +1,47 @@
+import json
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSTALLER_PATH = REPO_ROOT / "addons" / "godot_mcp" / "ui" / "mcp_cli_installer.gd"
+RELEASE_CONFIG_PATH = REPO_ROOT / "addons" / "godot_mcp" / "cli_release.json"
+POWERSHELL_INSTALLER_PATH = REPO_ROOT / "cli" / "gdmcp" / "packaging" / "install.ps1"
+POSIX_INSTALLER_PATH = REPO_ROOT / "cli" / "gdmcp" / "packaging" / "install.sh"
+
+
+class CliInstallerContractTests(unittest.TestCase):
+    def test_supported_release_targets_include_linux_arm64(self) -> None:
+        config = json.loads(RELEASE_CONFIG_PATH.read_text(encoding="utf-8"))
+        self.assertEqual(config["targets"]["aarch64-unknown-linux-gnu"], "gdmcp")
+
+    def test_ui_uses_godot_architecture_and_platform_install_scripts(self) -> None:
+        installer = INSTALLER_PATH.read_text(encoding="utf-8")
+
+        self.assertIn("Engine.get_architecture_name()", installer)
+        self.assertNotIn("OS.get_processor_name()", installer)
+        self.assertIn('"aarch64-unknown-linux-gnu"', installer)
+        self.assertIn('"aarch64-apple-darwin"', installer)
+        self.assertIn('"x86_64-apple-darwin"', installer)
+        self.assertIn('"x86_64-unknown-linux-gnu"', installer)
+        self.assertIn('"install.ps1"', installer)
+        self.assertIn('"install.sh"', installer)
+        self.assertIn("OS.execute", installer)
+        self.assertIn("ExpectedVersion", installer)
+        self.assertIn("expected-version", installer)
+        self.assertIn("exit_code", installer)
+
+    def test_packaged_installers_validate_expected_manifest_identity(self) -> None:
+        powershell = POWERSHELL_INSTALLER_PATH.read_text(encoding="utf-8")
+        posix = POSIX_INSTALLER_PATH.read_text(encoding="utf-8")
+
+        self.assertIn("ExpectedVersion", powershell)
+        self.assertIn("ExpectedTarget", powershell)
+        self.assertIn('package', powershell)
+        self.assertIn("--expected-version", posix)
+        self.assertIn("--expected-target", posix)
+        self.assertIn('package', posix)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## 根因

插件 UI 之前存在四个跨平台安装缺口：

- macOS 使用 `OS.get_processor_name()` 猜测架构，Apple M 系列名称不保证包含 `arm`
- Linux 始终选择 x86_64 包，Linux ARM64 会安装错误架构
- UI 只从 ZIP 中取出二进制，没有复用包内安装脚本
- 安装脚本会校验二进制 SHA-256，但不会校验期望版本和目标平台

## 修复

- 使用 `Engine.get_architecture_name()` 映射 Windows/Linux/macOS 的 x86_64/arm64 目标
- 在 `cli_release.json` 增加 `aarch64-unknown-linux-gnu`
- 下载后安全解压完整 ZIP，并拒绝绝对路径、盘符和 `..` 路径
- Windows 调用 `install.ps1`，Linux/macOS 调用 `install.sh`
- 向脚本传入期望版本和 target
- 安装脚本验证 manifest schema、package、version、target、executable 和 SHA-256
- POSIX 安装后设置执行权限
- UI 检查脚本退出码，并执行 `gdmcp --version` 做最终验证
- 失败时删除未通过版本验证的二进制

## 测试

- 新增 CLI installer contract tests
- POSIX 安装脚本真实安装测试
- 错误 target 拒绝测试
- 篡改二进制 SHA-256 拒绝测试
- CI 增加 Godot 4.6.1 `--check-only` GDScript 解析

本 PR 使用全新的 head 分支触发最终完整 CI；#60/#61 已关闭，代码内容由同一最终提交继承。