### PR TITLE
chore: retarget v1.0.8 tag

### DIFF
--- a/.github/tag-retarget-trigger
+++ b/.github/tag-retarget-trigger
@@ -1,0 +1,1 @@
+Retarget v1.0.8 to 97727060fac5fa570dbcf1ae0b8814a64cf0d6e0


### PR DESCRIPTION
一次性 Tag 移动触发 PR。GitHub 未为该临时工作流生成 Actions Run，因此没有移动 `v1.0.8`。临时工作流已从 `main` 删除，本 PR 未合并。