### PR TITLE
fix: 让 skills/ 进入仓库归档，修复技能管理器无法发现 SKILL.md

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,8 @@
 /**        export-ignore
 /addons    !export-ignore
 /addons/** !export-ignore
+
+# Keep the agent skills in the source archive so skill managers that install
+# from the GitHub archive URL can discover skills/*/SKILL.md.
+/skills    !export-ignore
+/skills/** !export-ignore


### PR DESCRIPTION
## 问题

用 cc-switch 之类的技能管理器添加本仓库后，扫不到任何 skill，`skills/gdmcp` 完全不出现——尽管 README 里把它作为配套的 agent skill 推荐给用户。

## 原因

`.gitattributes` 里的 export-ignore 规则把 `addons/` 以外的所有内容都排除了：

```
/**        export-ignore
/addons    !export-ignore
/addons/** !export-ignore
```

`export-ignore` 不只作用于 Asset Library，它对 **GitHub 自动生成的所有归档**都生效。实测：

```console
$ curl -sL https://github.com/yurineko73/Godot-MCP-Native/archive/refs/heads/main.zip -o m.zip
$ unzip -l m.zip | awk '{print $4}' | cut -d/ -f2 | sort -u
addons
```

整个归档只有 108 个文件、顶层只有 `addons/` 一个目录。`skills/gdmcp/SKILL.md` 和 `skills/release/SKILL.md` 都不在里面。

而技能管理器正是靠下载这个归档来安装的。以 cc-switch 为例，`src-tauri/src/services/skill.rs`：

- `download_repo()` 拼的就是 `https://github.com/{owner}/{name}/archive/refs/heads/{branch}.zip`
- 解压后 `scan_dir_recursive()` 递归查找 `SKILL.md`

扫描逻辑本身没问题，SKILL.md 的 frontmatter 也完全合规——文件压根没被下载下来，所以结果为空。

## 改动

给 `skills/` 加上 `!export-ignore`，让它能通过 `git archive`。

## 对 Asset Library 无影响

提交给 Asset Library 的不是 GitHub 自动归档，而是 `scripts/release.ps1` 单独构建的 `dist/godot-mcp-native-X.Y.Z.zip`——它从只含 `addons/godot_mcp` 的 staging 目录打包（release.ps1 L120-127），`skills/release/SKILL.md` 第 3 步也明确写的是提交这个产物。所以本改动不会让 `skills/` 出现在 Asset Library 安装包里。

## 验证

在本仓库实测 `git archive` 前后对比：

```console
# 改动前
$ git archive --format=zip HEAD | bsdtar -tf - | cut -d/ -f1 | sort -u
addons

# 改动后
$ git archive --format=zip HEAD | bsdtar -tf - | cut -d/ -f1 | sort -u
addons
skills

$ git archive --format=zip HEAD | bsdtar -tf - | grep -i skill
skills/gdmcp/SKILL.md
skills/gdmcp/references/command-workflows.md
skills/release/SKILL.md
```

`addons/` 的内容不受影响。

---

补充一个顺带发现的、本 PR 未涉及的问题：`scripts/release.ps1` L124-126 把插件复制到 `$staging\addons\godot_mcp`，但 `Compress-Archive` 打包的是 `$staging\godot-mcp-native-$Version`，这个目录从未被创建过。看起来会导致打包步骤报路径不存在。没有放进本 PR，避免混淆改动范围。