### PR TITLE
fix: 插件包顶层目录修复——release.ps1 打包崩溃 + CI 产出结构导致装错位置

### DIFF
--- a/.github/workflows/manual-gdmcp-release.yml
+++ b/.github/workflows/manual-gdmcp-release.yml
@@ -269,6 +269,10 @@ jobs:
           version = os.environ["VERSION"]
           source = Path("addons/godot_mcp")
           output = Path("dist") / f"godot-mcp-native-{version}.zip"
+          # Godot's asset installer strips the single root directory by default
+          # ("Ignore asset root"), so wrap addons/ in a versioned folder to make
+          # the plugin land in res://addons/godot_mcp/ instead of res://godot_mcp/.
+          root = Path(f"godot-mcp-native-{version}")
 
           if not source.is_dir():
               raise SystemExit(f"plugin directory was not found: {source}")
@@ -281,7 +285,7 @@ jobs:
           with zipfile.ZipFile(output, "w", compression=zipfile.ZIP_DEFLATED) as archive:
               for path in files:
                   relative = path.relative_to(source)
-                  archive_name = (Path("addons/godot_mcp") / relative).as_posix()
+                  archive_name = (root / "addons/godot_mcp" / relative).as_posix()
                   info = zipfile.ZipInfo(archive_name, date_time=(1980, 1, 1, 0, 0, 0))
                   info.compress_type = zipfile.ZIP_DEFLATED
                   info.create_system = 3

--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -118,12 +118,15 @@ if (-not $DryRun) {
 Write-Step "Step 4: Create plugin archive"
 if (-not $DryRun) {
     New-Item -ItemType Directory -Force -Path $DistDir | Out-Null
-    # Stage with addons/ prefix so extracted path is addons/godot_mcp/
+    # Stage as godot-mcp-native-$Version/addons/godot_mcp/. Godot's asset installer
+    # strips the single root directory by default ("Ignore asset root"), so the
+    # versioned wrapper is what makes the plugin land in res://addons/godot_mcp/.
     $staging = Join-Path ([IO.Path]::GetTempPath()) "gdmcp-zip-staging"
     if (Test-Path $staging) { Remove-Item -Recurse -Force $staging }
-    New-Item -Path "$staging\addons" -ItemType Directory -Force | Out-Null
-    Copy-Item -Recurse -Force "$RepoRoot\addons\godot_mcp" "$staging\addons\godot_mcp"
-    Compress-Archive -Path "$staging\godot-mcp-native-$Version" -DestinationPath $PluginZip -Force
+    $pluginRoot = Join-Path $staging "godot-mcp-native-$Version"
+    New-Item -Path "$pluginRoot\addons" -ItemType Directory -Force | Out-Null
+    Copy-Item -Recurse -Force "$RepoRoot\addons\godot_mcp" "$pluginRoot\addons\godot_mcp"
+    Compress-Archive -Path $pluginRoot -DestinationPath $PluginZip -Force
     Remove-Item -Recurse -Force $staging
     Write-Host "  $PluginZip"
 } else {

--- a/test/integration/test_manual_release_workflow.py
+++ b/test/integration/test_manual_release_workflow.py
@@ -31,6 +31,22 @@ class ManualReleaseWorkflowTests(unittest.TestCase):
             text,
         )
 
+    def test_plugin_zip_wraps_addons_in_versioned_root(self) -> None:
+        # Godot's asset installer detects a single root directory and strips it by
+        # default ("Ignore asset root"). Without the versioned wrapper the zip root
+        # is addons/, which gets stripped and installs to res://godot_mcp/ instead
+        # of res://addons/godot_mcp/.
+        text = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn(
+            'root = Path(f"godot-mcp-native-{version}")',
+            text,
+        )
+        self.assertIn(
+            'archive_name = (root / "addons/godot_mcp" / relative).as_posix()',
+            text,
+        )
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
两条发布路径产出的插件包结构都有问题，且互相不一致。

## 1. `scripts/release.ps1` Step 4 直接失败

76209a1 把 `Compress-Archive` 的目标改成了版本号目录，但没同步改 staging 的构建代码：

```powershell
New-Item -Path "$staging\addons" -ItemType Directory -Force | Out-Null
Copy-Item -Recurse -Force "$RepoRoot\addons\godot_mcp" "$staging\addons\godot_mcp"
Compress-Archive -Path "$staging\godot-mcp-native-$Version" ...   # 这个目录从没被创建过
```

staging 里只有 `$staging\addons\godot_mcp`，`$staging\godot-mcp-native-$Version` 从头到尾不存在，`Compress-Archive` 会直接报路径不存在。Step 4 目前是必失败的。

## 2. CI workflow 产出的结构会让插件装错位置

`manual-gdmcp-release.yml`（104efbd，比 76209a1 晚一天）把归档根写死成 `addons/godot_mcp`：

```python
archive_name = (Path("addons/godot_mcp") / relative).as_posix()
```

Godot 的 `EditorAssetInstaller::_check_has_toplevel()` 是**按名字无关**的方式识别单一根目录的——源码里没有对 `addons` 的任何特判，唯一的名字相关逻辑只是图标映射表。识别到单一根目录后，"Ignore asset root" 复选框默认勾选，`_update_file_mappings()` 里 `path = path.trim_prefix(toplevel_prefix)` 把它剥掉。

所以：

| zip 根 | 剥掉根之后 | 结果 |
|---|---|---|
| `addons/` | `godot_mcp/` | ❌ 装到 `res://godot_mcp/` |
| `godot-mcp-native-X.Y.Z/` | `addons/godot_mcp/` | ✅ 装到 `res://addons/godot_mcp/` |

也就是说 76209a1 想做的「版本号顶层目录」方向是对的，只是没实现成功；而后来的 CI 反而固化了会装错位置的那种结构。这个坑不是本仓库独有的，Orchestrator 的安装文档就专门警告用户必须手动取消勾选 "Ignore asset root"，否则装不对。

## 改动

两条路径统一产出 `godot-mcp-native-X.Y.Z/addons/godot_mcp/...`：

- `release.ps1`：先建出 `$pluginRoot = $staging\godot-mcp-native-$Version`，再往里放 `addons\godot_mcp`，然后 `Compress-Archive -Path $pluginRoot`
- `manual-gdmcp-release.yml`：归档名前缀加上版本号目录

## 验证

**CI 那段 Python 是实际跑过的**（把 heredoc 抽出来对着真实 `addons/godot_mcp` 执行）：

```console
$ VERSION=9.9.9 python3 wf_zip.py
dist/godot-mcp-native-9.9.9.zip
entries: 99
roots : ['godot-mcp-native-9.9.9']
剥掉单一根目录后 -> ['addons/']
samples:
   godot-mcp-native-9.9.9/addons/godot_mcp/LICENSE
   godot-mcp-native-9.9.9/addons/godot_mcp/README.md
OK: 所有条目都在 godot-mcp-native-9.9.9/addons/godot_mcp/ 下
```

**PowerShell 那段没有实机跑过**（手头是 macOS，装 pwsh 需要交互式 sudo），依据是微软文档里 `Compress-Archive` 的 `-Path` 语义：

> To create an archive that **includes** the root directory, and all its files and subdirectories, specify the root directory in the **Path** without wildcards. For example: `-Path C:\Reference`

也就是 Example 3 的行为。这和 1dd2ff9(#53) 里 `-Path "$staging\addons"` 产出 `addons/` 根是同一个用法，只是把目标换成了版本号目录。**建议合并前在 Windows 上跑一次 `.\scripts\release.ps1 -Version X.Y.Z -SkipTests` 确认。**

## 测试

`test_manual_release_workflow.py` 加了一条针对归档布局的回归测试。这个结构已经反复回归三次了（#52 → #53 → 76209a1），值得钉住。已确认它在未打补丁的 workflow 上会失败、打了补丁后通过：

```console
$ python3 -m unittest discover -s test/integration -p "test_manual_release_workflow.py"
Ran 3 tests in 0.000s
OK
```

现有两条断言只检查 zip 文件名和 artifact 名，不涉及内部结构，不受本改动影响。

---

另外确认过一点：`addons/godot_mcp` 下没有任何 dotfile，所以 `Compress-Archive` 会跳过隐藏文件这个特性不会让两条路径产出不一致。