### PR TITLE
fix(http): bind loopback by default and refresh security config

### DIFF
--- a/addons/godot_mcp/mcp_server_native.gd
+++ b/addons/godot_mcp/mcp_server_native.gd
@@ -319,6 +319,34 @@ func _apply_cmdline_overrides() -> void:
 		transport_mode = transport_override
 		_log_info("MCP transport overridden via command line: " + transport_mode)
 
+static func apply_http_security_config(
+		server: RefCounted,
+		enable_auth: bool,
+		token: String,
+		enable_remote: bool,
+		allowed_origin: String
+) -> void:
+	var auth_manager: McpAuthManager = null
+	if enable_auth:
+		auth_manager = McpAuthManager.new()
+		auth_manager.set_token(token)
+		auth_manager.set_enabled(true)
+	server.set_auth_manager(auth_manager)
+	if server.has_method("set_remote_config"):
+		server.set_remote_config(enable_remote, allowed_origin)
+
+func _sync_http_security_config() -> void:
+	if not _native_server or transport_mode != "http":
+		return
+	apply_http_security_config(
+		_native_server,
+		auth_enabled,
+		auth_token,
+		allow_remote,
+		cors_origin
+	)
+	_log_info("HTTP security config refreshed: auth=" + str(auth_enabled) + ", allow_remote=" + str(allow_remote))
+
 # ============================================================================
 # 插件配置（根据godot-dev-guide优化）
 # ============================================================================
@@ -496,6 +524,7 @@ func _start_native_server() -> bool:
 	# distinct ports regardless of mcp_settings.cfg. A pure no-op without
 	# overrides (parse_mcp_overrides returns -1 / "").
 	_apply_cmdline_overrides()
+	_sync_http_security_config()
 
 	_log_info("Starting native MCP server...")
 	var success: bool = _native_server.start()

--- a/addons/godot_mcp/native_mcp/mcp_http_server_legacy.gd
+++ b/addons/godot_mcp/native_mcp/mcp_http_server_legacy.gd
@@ -104,7 +104,7 @@ func start() -> bool:
 	
 	_tcp_server = TCPServer.new()
 	
-	var error: Error = _tcp_server.listen(_port)
+	var error: Error = _tcp_server.listen(_port, _get_bind_address())
 	if error != OK:
 		var error_msg: String = "Failed to listen on port " + str(_port) + ": " + str(error)
 		server_error.emit(error_msg)
@@ -121,6 +121,9 @@ func start() -> bool:
 		_log_callback.call("INFO", "Server started on port " + str(_port))
 	
 	return true
+
+func _get_bind_address() -> String:
+	return "*" if _allow_remote else "127.0.0.1"
 
 func _check_port_conflict(port: int) -> String:
 	var os_name: String = OS.get_name()

--- a/addons/godot_mcp/native_mcp/mcp_server_core.gd
+++ b/addons/godot_mcp/native_mcp/mcp_server_core.gd
@@ -22,6 +22,7 @@ func _init_transport() -> bool:
 		TransportType.TRANSPORT_HTTP:
 			_transport = load("res://addons/godot_mcp/native_mcp/mcp_http_server.gd").new()
 			_transport.set_port(_http_port)
+			_transport.set_remote_config(_allow_remote, _cors_origin)
 			if _auth_manager:
 				_transport.set_auth_manager(_auth_manager)
 			if _transport.has_method("set_log_callback"):

--- a/addons/godot_mcp/native_mcp/mcp_server_core_legacy.gd
+++ b/addons/godot_mcp/native_mcp/mcp_server_core_legacy.gd
@@ -50,6 +50,8 @@ var _transport_type: TransportType = TransportType.TRANSPORT_STDIO
 var _transport: McpTransportBase = null  # 传输层实例（使用基类类型）
 var _auth_manager: McpAuthManager = null  # 认证管理器（HTTP 模式使用）
 var _http_port: int = 9080  # HTTP 监听端口
+var _allow_remote: bool = false
+var _cors_origin: String = "*"
 
 # 消息队列（使用类型化数组 - 根据godot-dev-guide）
 var _message_queue: Array[Dictionary] = []
@@ -113,6 +115,8 @@ func set_sse_enabled(enabled: bool) -> void:
 	_log_info("SSE enabled: " + str(enabled))
 
 func set_remote_config(allow_remote: bool, cors_origin: String) -> void:
+	_allow_remote = allow_remote
+	_cors_origin = cors_origin
 	if _transport and _transport.has_method("set_remote_config"):
 		_transport.set_remote_config(allow_remote, cors_origin)
 	_log_info("Remote config - allow: " + str(allow_remote) + ", CORS: " + cors_origin)
@@ -130,6 +134,7 @@ func _init_transport() -> bool:
 		TransportType.TRANSPORT_HTTP:
 			_transport = McpHttpServer.new()
 			_transport.set_port(_http_port)
+			_transport.set_remote_config(_allow_remote, _cors_origin)
 			if _auth_manager:
 				_transport.set_auth_manager(_auth_manager)
 			if _transport.has_method("set_log_callback"):

--- a/test/integration/test_http_listener_security_flow.py
+++ b/test/integration/test_http_listener_security_flow.py
@@ -1,0 +1,241 @@
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_DIR = Path(__file__).resolve().parent
+DEFAULT_GODOT_EXE = Path(r"C:\SourceCode\Godot_v4.6.2-stable_mono_win64\Godot_v4.6.2-stable_mono_win64_console.exe")
+
+
+def find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.bind(("127.0.0.1", 0))
+        return listener.getsockname()[1]
+
+
+def find_lan_address() -> str:
+    candidates: set[str] = set()
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as probe:
+            probe.connect(("192.0.2.1", 9))
+            candidates.add(probe.getsockname()[0])
+    except OSError:
+        pass
+    try:
+        for result in socket.getaddrinfo(socket.gethostname(), None, socket.AF_INET):
+            candidates.add(result[4][0])
+    except socket.gaierror:
+        pass
+    for address in sorted(candidates):
+        if not address.startswith("127.") and not address.startswith("169.254."):
+            return address
+    raise RuntimeError("No non-loopback IPv4 address is available for the LAN binding check")
+
+
+def request_initialize(host: str, port: int, token: str = "") -> tuple[int, dict]:
+    body = json.dumps({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-11-25",
+            "capabilities": {},
+            "clientInfo": {"name": "http-security-test", "version": "1.0"},
+        },
+    }).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(
+        f"http://{host}:{port}/mcp",
+        data=body,
+        headers=headers,
+        method="POST",
+    )
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+    try:
+        with opener.open(request, timeout=3) as response:
+            return response.status, json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        response_body = error.read().decode("utf-8")
+        try:
+            payload = json.loads(response_body)
+        except json.JSONDecodeError:
+            payload = {"error": response_body}
+        return error.code, payload
+
+
+def wait_for_listener(port: int, process: subprocess.Popen[str], timeout_seconds: float = 45.0) -> None:
+    deadline = time.time() + timeout_seconds
+    while time.time() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError(f"Godot exited before the HTTP listener started (exit={process.returncode})")
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+                return
+        except OSError:
+            time.sleep(0.25)
+    raise TimeoutError(f"Timed out waiting for the MCP listener on 127.0.0.1:{port}")
+
+
+def prepare_isolated_user_data(temp_dir: Path, settings: dict[str, object]) -> dict[str, str]:
+    environment = os.environ.copy()
+    home_dir = temp_dir / "home"
+    home_dir.mkdir()
+    environment["HOME"] = str(home_dir)
+    if sys.platform == "darwin":
+        data_root = home_dir / "Library" / "Application Support" / "Godot" / "app_userdata"
+    elif os.name == "nt":
+        app_data = home_dir / "AppData" / "Roaming"
+        environment["APPDATA"] = str(app_data)
+        data_root = app_data / "Godot" / "app_userdata"
+    else:
+        xdg_data = home_dir / ".local" / "share"
+        environment["XDG_DATA_HOME"] = str(xdg_data)
+        data_root = xdg_data / "godot" / "app_userdata"
+
+    settings_dir = data_root / "Godot MCP Native"
+    settings_dir.mkdir(parents=True)
+    lines = ["[meta]", "version=1", "", "[settings]"]
+    for key, value in settings.items():
+        if isinstance(value, bool):
+            encoded = "true" if value else "false"
+        elif isinstance(value, str):
+            encoded = json.dumps(value)
+        else:
+            encoded = str(value)
+        lines.append(f"{key}={encoded}")
+    (settings_dir / "mcp_settings.cfg").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return environment
+
+
+@contextmanager
+def running_editor(
+    godot_exe: Path,
+    settings: dict[str, object],
+) -> Iterator[tuple[int, str]]:
+    port = find_free_port()
+    temp_dir = Path(tempfile.mkdtemp(prefix=".tmp_http_listener_security_", dir=SCRIPT_DIR))
+    log_path = temp_dir / "godot.log"
+    process: subprocess.Popen[str] | None = None
+    log_text = ""
+    try:
+        environment = prepare_isolated_user_data(temp_dir, settings)
+        with log_path.open("w", encoding="utf-8") as log_file:
+            process = subprocess.Popen(
+                [
+                    str(godot_exe),
+                    "--editor",
+                    "--headless",
+                    "--path",
+                    str(REPO_ROOT),
+                    "--",
+                    "--mcp-server",
+                    f"--mcp-port={port}",
+                ],
+                cwd=REPO_ROOT,
+                env=environment,
+                stdout=log_file,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+            wait_for_listener(port, process)
+            yield port, str(log_path)
+    except Exception:
+        if log_path.exists():
+            log_text = log_path.read_text(encoding="utf-8", errors="replace")
+            print(log_text)
+        raise
+    finally:
+        if process is not None and process.poll() is None:
+            process.terminate()
+            try:
+                process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=5)
+        if log_path.exists():
+            log_text = log_path.read_text(encoding="utf-8", errors="replace")
+        token = settings.get("auth_token")
+        shutil.rmtree(temp_dir, ignore_errors=True)
+        if isinstance(token, str) and token and token in log_text:
+            raise AssertionError("Godot output exposed the configured bearer token")
+
+
+def assert_default_loopback_policy(godot_exe: Path, lan_address: str) -> None:
+    with running_editor(
+        godot_exe,
+        {"transport_mode": "http", "auth_enabled": False, "allow_remote": False},
+    ) as (port, _log_path):
+        local_status, local_payload = request_initialize("127.0.0.1", port)
+        if local_status != 200 or "result" not in local_payload:
+            raise AssertionError(
+                f"Loopback initialize failed: status={local_status}, payload={local_payload}"
+            )
+
+        try:
+            lan_status, lan_payload = request_initialize(lan_address, port)
+        except (OSError, urllib.error.URLError):
+            pass
+        else:
+            raise AssertionError(
+                "Default listener accepted a LAN connection: "
+                f"address={lan_address}, status={lan_status}, payload={lan_payload}"
+            )
+    print(f"PASS: default listener accepted loopback and refused LAN address {lan_address}")
+
+
+def assert_remote_authenticated_policy(godot_exe: Path, lan_address: str) -> None:
+    token = "http-security-test-token-123456"
+    with running_editor(
+        godot_exe,
+        {
+            "transport_mode": "http",
+            "auth_enabled": True,
+            "auth_token": token,
+            "allow_remote": True,
+            "cors_origin": "https://editor.example",
+        },
+    ) as (port, _log_path):
+        unauthenticated_status, _payload = request_initialize("127.0.0.1", port)
+        if unauthenticated_status != 401:
+            raise AssertionError(
+                f"Authenticated listener accepted a request without a token: status={unauthenticated_status}"
+            )
+        local_status, local_payload = request_initialize("127.0.0.1", port, token)
+        if local_status != 200 or "result" not in local_payload:
+            raise AssertionError(
+                f"Authenticated loopback initialize failed: status={local_status}, payload={local_payload}"
+            )
+        lan_status, lan_payload = request_initialize(lan_address, port, token)
+        if lan_status != 200 or "result" not in lan_payload:
+            raise AssertionError(
+                f"Remote-enabled LAN initialize failed: status={lan_status}, payload={lan_payload}"
+            )
+    print(f"PASS: remote listener required auth and accepted LAN address {lan_address}")
+
+
+def main() -> int:
+    godot_exe = Path(os.environ.get("GODOT_EXE", str(DEFAULT_GODOT_EXE)))
+    if not godot_exe.exists():
+        raise FileNotFoundError(f"Godot executable not found: {godot_exe}")
+
+    lan_address = find_lan_address()
+    assert_default_loopback_policy(godot_exe, lan_address)
+    assert_remote_authenticated_policy(godot_exe, lan_address)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/unit/test_mcp_http_server.gd
+++ b/test/unit/test_mcp_http_server.gd
@@ -91,6 +91,13 @@ func test_set_remote_config():
 	assert_eq(_http_server._allow_remote, true, "Allow remote should be true")
 	assert_eq(_http_server._cors_origin, "http://localhost:3000", "CORS origin should be set")
 
+func test_listener_bind_address_defaults_to_loopback():
+	assert_eq(_http_server._get_bind_address(), "127.0.0.1", "Default listener should bind to loopback")
+
+func test_listener_bind_address_allows_all_interfaces_when_remote_enabled():
+	_http_server.set_remote_config(true, "*")
+	assert_eq(_http_server._get_bind_address(), "*", "Remote-enabled listener should bind to all interfaces")
+
 func test_max_request_size_constant():
 	assert_eq(_http_server.MAX_REQUEST_SIZE, 1024 * 1024, "Max request size should be 1MB")
 

--- a/test/unit/test_mcp_server_core.gd
+++ b/test/unit/test_mcp_server_core.gd
@@ -197,6 +197,42 @@ func test_set_rate_limit():
 func test_is_running_initially():
 	assert_false(_core.is_running(), "Should not be running initially")
 
+func test_remote_config_is_applied_when_http_transport_is_created():
+	_core.set_transport_type(MCPServerCore.TransportType.TRANSPORT_HTTP)
+	_core.set_remote_config(true, "https://editor.example")
+	assert_null(_core._transport, "Transport should not exist before initialization")
+	assert_true(_core._init_transport(), "HTTP transport should initialize")
+	assert_true(_core._transport._allow_remote, "Cached remote access should reach the new transport")
+	assert_eq(_core._transport._cors_origin, "https://editor.example", "Cached CORS origin should reach the new transport")
+
+func test_recreated_http_transport_uses_latest_remote_config():
+	_core.set_transport_type(MCPServerCore.TransportType.TRANSPORT_HTTP)
+	_core.set_remote_config(false, "https://first.example")
+	assert_true(_core._init_transport(), "First HTTP transport should initialize")
+	_core.set_remote_config(true, "https://second.example")
+	_core._transport = null
+	assert_true(_core._init_transport(), "Recreated HTTP transport should initialize")
+	assert_true(_core._transport._allow_remote, "Recreated transport should use the latest remote access setting")
+	assert_eq(_core._transport._cors_origin, "https://second.example", "Recreated transport should use the latest CORS origin")
+
+func test_recreated_http_transport_uses_latest_auth_manager():
+	_core.set_transport_type(MCPServerCore.TransportType.TRANSPORT_HTTP)
+	var first_auth: McpAuthManager = McpAuthManager.new()
+	first_auth.set_token("first-auth-token-1234")
+	_core.set_auth_manager(first_auth)
+	assert_true(_core._init_transport(), "First HTTP transport should initialize")
+	assert_same(_core._transport._auth_manager, first_auth, "First auth manager should reach the transport")
+	var second_auth: McpAuthManager = McpAuthManager.new()
+	second_auth.set_token("second-auth-token-123")
+	_core.set_auth_manager(second_auth)
+	_core._transport = null
+	assert_true(_core._init_transport(), "Recreated HTTP transport should initialize")
+	assert_same(_core._transport._auth_manager, second_auth, "Recreated transport should use the latest auth manager")
+	_core.set_auth_manager(null)
+	_core._transport = null
+	assert_true(_core._init_transport(), "Transport should initialize after auth is disabled")
+	assert_null(_core._transport._auth_manager, "Recreated transport should clear stale auth")
+
 func test_protocol_version_constant():
 	assert_eq(MCPTypes.PROTOCOL_VERSION, "2025-11-25", "Protocol version should be 2025-11-25")
 

--- a/test/unit/test_mcp_server_native.gd
+++ b/test/unit/test_mcp_server_native.gd
@@ -1,5 +1,17 @@
 extends "res://addons/gut/test.gd"
 
+class FakeSecurityServer extends RefCounted:
+	var auth_manager: McpAuthManager = null
+	var allow_remote: bool = false
+	var cors_origin: String = ""
+
+	func set_auth_manager(manager: McpAuthManager) -> void:
+		auth_manager = manager
+
+	func set_remote_config(remote_enabled: bool, allowed_origin: String) -> void:
+		allow_remote = remote_enabled
+		cors_origin = allowed_origin
+
 var _plugin_script: GDScript = null
 
 func before_each():
@@ -44,6 +56,37 @@ func test_plugin_has_get_server_status():
 	var methods: Array = _plugin_script.get_script_method_list()
 	var method_names: Array = methods.map(func(m): return m["name"])
 	assert_true(method_names.has("get_server_status"), "Should have get_server_status method")
+
+func test_http_security_sync_applies_current_remote_and_auth_config():
+	var server: FakeSecurityServer = FakeSecurityServer.new()
+	_plugin_script.apply_http_security_config(
+		server,
+		true,
+		"1234567890abcdef",
+		true,
+		"https://editor.example"
+	)
+	assert_ne(server.auth_manager, null, "Enabled auth should install a manager")
+	assert_true(
+		server.auth_manager.validate_request({"authorization": "Bearer 1234567890abcdef"}),
+		"Installed auth manager should use the latest token"
+	)
+	assert_true(server.allow_remote, "Latest remote access setting should be applied")
+	assert_eq(server.cors_origin, "https://editor.example", "Latest CORS origin should be applied")
+
+func test_http_security_sync_clears_stale_auth_manager():
+	var server: FakeSecurityServer = FakeSecurityServer.new()
+	server.auth_manager = McpAuthManager.new()
+	_plugin_script.apply_http_security_config(server, false, "", false, "*")
+	assert_null(server.auth_manager, "Disabled auth should clear a manager from an earlier start")
+
+func test_start_syncs_http_security_before_transport_start():
+	var start_source: String = _get_function_source("_start_native_server")
+	var sync_position: int = start_source.find("_sync_http_security_config()")
+	var start_position: int = start_source.find("_native_server.start()")
+	assert_true(sync_position >= 0, "Start should refresh HTTP security configuration")
+	assert_true(start_position >= 0, "Start should invoke the server core")
+	assert_true(sync_position < start_position, "Security configuration should refresh before the listener starts")
 
 func test_find_files_recursive():
 	var result: Array = []


### PR DESCRIPTION
## Summary

- bind the unauthenticated HTTP MCP listener to 127.0.0.1 by default
- bind all interfaces only when allow_remote is enabled
- cache and reapply remote/CORS settings whenever the HTTP transport is created
- refresh remote and authentication settings before every server start, including clearing stale authentication managers

## Security impact

Before this change, TCPServer.listen was called without a bind address, so Godot listened on every IPv4/IPv6 interface even when allow_remote was false. A LAN client could initialize the MCP endpoint without authentication under the default settings.

## Tests

TDD RED reproduced against the parent commit:

- loopback initialize returned HTTP 200
- the same initialize request through the machine LAN address also returned HTTP 200

GREEN after the fix:

- default listener: loopback HTTP 200, LAN connection refused
- allow_remote=true with authentication: missing token HTTP 401
- correct bearer token: loopback and LAN initialize HTTP 200
- the configured token is asserted absent from the Godot process log

Command used:

    GODOT_EXE=/opt/homebrew/bin/godot python3 test/integration/test_http_listener_security_flow.py

Focused GUT coverage was added for listener bind policy, remote/CORS caching and transport recreation, authentication replacement/clear, and plugin pre-start synchronization. All newly added tests pass.

The combined related GUT run reported 80/83 passing. The three failures already exist on the parent commit and are unrelated to this patch:

- test_set_group_enabled_disables_group
- test_set_group_enabled_re_enables_group
- test_async_tool_call_with_await

Tested with Godot 4.6.2 on macOS.