### PR TITLE
fix(project-tests): accept the default test root path

### DIFF
--- a/addons/godot_mcp/tools/project_tools_native.gd
+++ b/addons/godot_mcp/tools/project_tools_native.gd
@@ -784,7 +784,10 @@ func _validate_test_path(path: String, expect_directory: bool) -> Dictionary:
 		return {"error": "Test path cannot be empty"}
 	if not path.begins_with("res://"):
 		return {"error": "Test path must start with res://"}
-	if not (path.begins_with("res://test/") or path.begins_with("res://.tmp_") or path.contains("/.tmp_")):
+	for path_segment in path.split("/", false):
+		if path_segment == "..":
+			return {"error": "Test path cannot contain traversal segments"}
+	if not ((expect_directory and path == "res://test") or path.begins_with("res://test/") or path.begins_with("res://.tmp_") or path.contains("/.tmp_")):
 		return {"error": "Test path must stay under res://test/ or a temporary test directory"}
 	var validation: Dictionary = PathValidator.validate_directory_path(path) if expect_directory else PathValidator.validate_path(path)
 	if not validation.get("valid", false):

--- a/test/unit/tools/test_project_tools.gd
+++ b/test/unit/tools/test_project_tools.gd
@@ -140,3 +140,47 @@ func test_get_class_api_metadata_reports_missing_class():
 	var project_tools: RefCounted = load("res://addons/godot_mcp/tools/project_tools_native.gd").new()
 	var result: Dictionary = project_tools._tool_get_class_api_metadata({"class_name": "DefinitelyMissingClass123"})
 	assert_has(result, "error", "Missing classes should return an error payload")
+
+func test_list_project_tests_uses_default_test_root_for_missing_or_blank_search_path():
+	var project_tools: RefCounted = load("res://addons/godot_mcp/tools/project_tools_native.gd").new()
+	var default_result: Dictionary = project_tools._tool_list_project_tests({})
+	var blank_result: Dictionary = project_tools._tool_list_project_tests({"search_path": "   "})
+	assert_false(default_result.has("error"), "Default search should reach test discovery")
+	assert_false(blank_result.has("error"), "Blank search should use the default test root")
+	assert_eq(default_result.search_path, "res://test/", "Default search should use the test root directory")
+	assert_eq(blank_result.search_path, "res://test/", "Blank search should use the test root directory")
+	for entry in default_result.tests:
+		assert_true(str(entry.get("test_path", "")).begins_with("res://test/"), "Default search should only return tests under the test root")
+	for entry in blank_result.tests:
+		assert_true(str(entry.get("test_path", "")).begins_with("res://test/"), "Blank search should only return tests under the test root")
+
+func test_run_project_tests_uses_default_test_root_without_executing_discovered_tests():
+	var project_tools: RefCounted = load("res://addons/godot_mcp/tools/project_tools_native.gd").new()
+	var default_result: Dictionary = project_tools._tool_run_project_tests({"framework": "unsupported"})
+	var blank_result: Dictionary = project_tools._tool_run_project_tests({"search_path": "   ", "framework": "unsupported"})
+	assert_false(default_result.has("error"), "Default batch run should reach discovery")
+	assert_false(blank_result.has("error"), "Blank batch search should use the default test root")
+	assert_eq(default_result.search_path, "res://test/", "Default batch run should use the test root directory")
+	assert_eq(blank_result.search_path, "res://test/", "Blank batch run should use the test root directory")
+	assert_eq(default_result.total_count, 0, "An unsupported framework should avoid executing project tests")
+	assert_eq(blank_result.total_count, 0, "An unsupported framework should avoid executing project tests")
+
+func test_project_test_tools_reject_paths_outside_test_tree_and_traversal():
+	var project_tools: RefCounted = load("res://addons/godot_mcp/tools/project_tools_native.gd").new()
+	var outside_result: Dictionary = project_tools._tool_list_project_tests({"search_path": "res://addons"})
+	var traversal_result: Dictionary = project_tools._tool_list_project_tests({"search_path": "res://test/../addons"})
+	var batch_outside_result: Dictionary = project_tools._tool_run_project_tests({"search_path": "res://addons"})
+	assert_has(outside_result, "error", "Test discovery must reject directories outside the test tree")
+	assert_has(traversal_result, "error", "Test discovery must reject traversal outside the test tree")
+	assert_has(batch_outside_result, "error", "Batch test execution must preserve the discovery path boundary")
+
+func test_validate_test_path_rejects_traversal_segments_before_sanitization():
+	var project_tools: RefCounted = load("res://addons/godot_mcp/tools/project_tools_native.gd").new()
+	for traversal_path in ["res://test/../addons", "res://test/../../addons", "res://test//../addons"]:
+		var result: Dictionary = project_tools._validate_test_path(traversal_path, true)
+		assert_has(result, "error", "Test path traversal must be rejected before sanitization: " + traversal_path)
+
+func test_validate_test_path_allows_temporary_integration_directory():
+	var project_tools: RefCounted = load("res://addons/godot_mcp/tools/project_tools_native.gd").new()
+	var result: Dictionary = project_tools._validate_test_path("res://test/integration/.tmp_project_test_path", true)
+	assert_false(result.has("error"), "Temporary integration directories should remain valid test roots")


### PR DESCRIPTION
## Summary

- accept the documented default res://test directory in project test discovery and batch execution
- keep single-test file validation unchanged
- reject raw path traversal segments before the shared path sanitizer can rewrite them
- cover missing and blank default paths for list_project_tests and run_project_tests

## Bug

Both project test tools default to res://test, but the path policy only accepted paths beginning with res://test/. Calling either tool with its documented defaults therefore failed before test discovery.

During review, the regression test also exposed that the shared sanitizer removes .. before strict validation. This patch rejects exact .. path segments at the project-test boundary so traversal cannot be disguised as a missing directory.

## Tests

TDD RED against the parent commit:

- list_project_tests with no search_path returned Test path must stay under res://test/
- traversal cases were sanitized into apparently valid paths instead of being rejected

GREEN:

- default and blank list paths normalize to res://test/
- default and blank batch paths reach discovery without executing the full suite
- res://test/../addons, res://test/../../addons, and res://test//../addons are rejected before sanitization
- the existing temporary integration-test directory policy remains accepted
- paths outside the test tree remain rejected

Focused GUT result:

    17/17 tests passed
    269 assertions passed

Tested with Godot 4.6.2 on macOS.