### PR TITLE
fix(http): support dual-stack loopback listeners

### DIFF
--- a/addons/godot_mcp/mcp_server_native.gd
+++ b/addons/godot_mcp/mcp_server_native.gd
@@ -319,6 +319,40 @@ func _apply_cmdline_overrides() -> void:
 		transport_mode = transport_override
 		_log_info("MCP transport overridden via command line: " + transport_mode)
 
+static func sync_server_start_config(
+	server: RefCounted,
+	current_transport_mode: String,
+	current_http_port: int,
+	current_allow_remote: bool,
+	current_cors_origin: String,
+	current_auth_enabled: bool,
+	current_auth_token: String
+) -> void:
+	if server == null:
+		return
+	var type: int = MCPServerCore.TransportType.TRANSPORT_STDIO \
+		if current_transport_mode == "stdio" else MCPServerCore.TransportType.TRANSPORT_HTTP
+	server.set_transport_type(type)
+	server.set_http_port(current_http_port)
+	server.set_remote_config(current_allow_remote, current_cors_origin)
+	var auth_manager: McpAuthManager = null
+	if current_auth_enabled and current_transport_mode == "http":
+		auth_manager = McpAuthManager.new()
+		auth_manager.set_token(current_auth_token)
+		auth_manager.set_enabled(true)
+	server.set_auth_manager(auth_manager)
+
+func _sync_server_start_config() -> void:
+	sync_server_start_config(
+		_native_server,
+		transport_mode,
+		http_port,
+		allow_remote,
+		cors_origin,
+		auth_enabled,
+		auth_token
+	)
+
 # ============================================================================
 # 插件配置（根据godot-dev-guide优化）
 # ============================================================================
@@ -496,6 +530,7 @@ func _start_native_server() -> bool:
 	# distinct ports regardless of mcp_settings.cfg. A pure no-op without
 	# overrides (parse_mcp_overrides returns -1 / "").
 	_apply_cmdline_overrides()
+	_sync_server_start_config()
 
 	_log_info("Starting native MCP server...")
 	var success: bool = _native_server.start()

--- a/addons/godot_mcp/native_mcp/mcp_http_server_legacy.gd
+++ b/addons/godot_mcp/native_mcp/mcp_http_server_legacy.gd
@@ -35,8 +35,8 @@ const AUTH_SCHEME: String = "Bearer"
 # 状态变量（带类型提示 - 根据 godot-dev-guide）
 # ==============================================================================
 
-## TCP 服务器实例
-var _tcp_server: TCPServer = null
+## Active TCP listeners
+var _tcp_servers: Array[TCPServer] = []
 
 ## 监听端口
 var _port: int = 9080
@@ -93,24 +93,22 @@ func set_auth_manager(manager: RefCounted) -> void:
 ## 启动 HTTP 服务器
 ## @returns: bool - 启动成功返回 true，失败返回 false
 func start() -> bool:
-	var conflict_info: String = _check_port_conflict(_port)
-	if not conflict_info.is_empty():
-		var error_msg: String = "Port " + str(_port) + " is already in use! " + conflict_info + " Please change the port in MCP settings or close the conflicting application."
-		server_error.emit(error_msg)
-		if _log_callback.is_valid():
-			_log_callback.call("ERROR", error_msg)
-		push_error(error_msg)
+	if _active:
 		return false
-	
-	_tcp_server = TCPServer.new()
-	
-	var error: Error = _tcp_server.listen(_port)
-	if error != OK:
-		var error_msg: String = "Failed to listen on port " + str(_port) + ": " + str(error)
-		server_error.emit(error_msg)
-		if _log_callback.is_valid():
-			_log_callback.call("ERROR", error_msg)
-		return false
+
+	for bind_address in _get_bind_addresses():
+		var tcp_server: TCPServer = TCPServer.new()
+		var error: Error = tcp_server.listen(_port, bind_address)
+		if error != OK:
+			tcp_server.stop()
+			_stop_listeners()
+			var error_msg: String = "Failed to listen on " + bind_address + ":" + str(_port) + ": " + str(error)
+			server_error.emit(error_msg)
+			if _log_callback.is_valid():
+				_log_callback.call("ERROR", error_msg)
+			push_error(error_msg)
+			return false
+		_tcp_servers.append(tcp_server)
 	
 	_active = true
 	_thread = Thread.new()
@@ -118,9 +116,20 @@ func start() -> bool:
 	
 	server_started.emit()
 	if _log_callback.is_valid():
-		_log_callback.call("INFO", "Server started on port " + str(_port))
+		_log_callback.call("INFO", "Server started on " + ", ".join(_get_bind_addresses()) + ":" + str(_port))
 	
 	return true
+
+func _get_bind_addresses() -> PackedStringArray:
+	if _allow_remote:
+		return PackedStringArray(["*"])
+	return PackedStringArray(["127.0.0.1", "::1"])
+
+func _stop_listeners() -> void:
+	for tcp_server in _tcp_servers:
+		if tcp_server:
+			tcp_server.stop()
+	_tcp_servers.clear()
 
 func _check_port_conflict(port: int) -> String:
 	var os_name: String = OS.get_name()
@@ -214,15 +223,16 @@ func _resolve_process_name_linux(pid: String) -> String:
 func stop() -> void:
 	_active = false
 	
-	# 停止 TCP 服务器（不再接受新连接）
-	if _tcp_server:
-		_tcp_server.stop()
-		_tcp_server = null
+	# Stop accepting new connections before joining the server thread.
+	for tcp_server in _tcp_servers:
+		if tcp_server:
+			tcp_server.stop()
 	
 	# 等待线程结束（必须在线程退出后再修改共享数据）
 	if _thread and _thread.is_alive():
 		_thread.wait_to_finish()
 	_thread = null
+	_tcp_servers.clear()
 	
 	# 线程已退出，安全清理连接
 	for peer in _connections:
@@ -238,7 +248,12 @@ func stop() -> void:
 ## 检查传输层是否正在运行
 ## @returns: bool - 运行中返回 true，否则返回 false
 func is_running() -> bool:
-	return _active and _tcp_server != null and _tcp_server.is_listening()
+	if not _active or _tcp_servers.is_empty():
+		return false
+	for tcp_server in _tcp_servers:
+		if not tcp_server or not tcp_server.is_listening():
+			return false
+	return true
 
 
 # ==============================================================================
@@ -253,17 +268,17 @@ func _http_server_loop() -> void:
 	var last_keepalive: int = Time.get_ticks_msec()
 	
 	while _active:
-		if not _tcp_server:
+		if _tcp_servers.is_empty():
 			break
 		
-		# 检查新连接
-		var peer: StreamPeerTCP = null
-		if _tcp_server.is_connection_available():
-			peer = _tcp_server.take_connection()
-		if peer:
-			_connections.append(peer)
-			if _log_callback.is_valid():
-				_log_callback.call("INFO", "New connection: " + str(peer.get_status()))
+		# Accept new connections from every configured address.
+		for tcp_server in _tcp_servers:
+			if tcp_server.is_connection_available():
+				var peer: StreamPeerTCP = tcp_server.take_connection()
+				if peer:
+					_connections.append(peer)
+					if _log_callback.is_valid():
+						_log_callback.call("INFO", "New connection: " + str(peer.get_status()))
 		
 		# 处理所有活跃连接（复制一份避免并发修改）
 		var disconnected: Array[StreamPeerTCP] = []

--- a/addons/godot_mcp/native_mcp/mcp_server_core.gd
+++ b/addons/godot_mcp/native_mcp/mcp_server_core.gd
@@ -24,6 +24,7 @@ func _init_transport() -> bool:
 			_transport.set_port(_http_port)
 			if _auth_manager:
 				_transport.set_auth_manager(_auth_manager)
+			_transport.set_remote_config(_allow_remote, _cors_origin)
 			if _transport.has_method("set_log_callback"):
 				_transport.set_log_callback(_log_transport_message)
 			_log_info("Initialized HTTP transport on port " + str(_http_port))

--- a/addons/godot_mcp/native_mcp/mcp_server_core_legacy.gd
+++ b/addons/godot_mcp/native_mcp/mcp_server_core_legacy.gd
@@ -50,6 +50,8 @@ var _transport_type: TransportType = TransportType.TRANSPORT_STDIO
 var _transport: McpTransportBase = null  # 传输层实例（使用基类类型）
 var _auth_manager: McpAuthManager = null  # 认证管理器（HTTP 模式使用）
 var _http_port: int = 9080  # HTTP 监听端口
+var _allow_remote: bool = false
+var _cors_origin: String = "*"
 
 # 消息队列（使用类型化数组 - 根据godot-dev-guide）
 var _message_queue: Array[Dictionary] = []
@@ -113,6 +115,8 @@ func set_sse_enabled(enabled: bool) -> void:
 	_log_info("SSE enabled: " + str(enabled))
 
 func set_remote_config(allow_remote: bool, cors_origin: String) -> void:
+	_allow_remote = allow_remote
+	_cors_origin = cors_origin
 	if _transport and _transport.has_method("set_remote_config"):
 		_transport.set_remote_config(allow_remote, cors_origin)
 	_log_info("Remote config - allow: " + str(allow_remote) + ", CORS: " + cors_origin)
@@ -132,6 +136,7 @@ func _init_transport() -> bool:
 			_transport.set_port(_http_port)
 			if _auth_manager:
 				_transport.set_auth_manager(_auth_manager)
+			_transport.set_remote_config(_allow_remote, _cors_origin)
 			if _transport.has_method("set_log_callback"):
 				_transport.set_log_callback(_log_transport_message)
 			_log_info("Initialized HTTP transport on port " + str(_http_port))

--- a/test/integration/test_http_dual_loopback_binding.py
+++ b/test/integration/test_http_dual_loopback_binding.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import http.client
+import json
+import os
+import platform
+import re
+import shutil
+import socket
+import subprocess
+import tempfile
+import time
+import unittest
+import uuid
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_GODOT_EXE = Path("/Applications/Godot-4.6.2.app/Contents/MacOS/Godot")
+
+
+def find_free_port() -> int:
+	with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+		listener.bind(("127.0.0.1", 0))
+		return int(listener.getsockname()[1])
+
+
+def find_non_loopback_ipv4() -> str:
+	candidates: list[str] = []
+	try:
+		for result in socket.getaddrinfo(
+			socket.gethostname(), 0, family=socket.AF_INET, type=socket.SOCK_STREAM
+		):
+			candidates.append(result[4][0])
+	except socket.gaierror:
+		pass
+
+	with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as probe:
+		try:
+			probe.connect(("192.0.2.1", 9))
+			candidates.append(probe.getsockname()[0])
+		except OSError:
+			pass
+
+	for candidate in candidates:
+		if not candidate.startswith("127.") and candidate != "0.0.0.0":
+			return candidate
+	return ""
+
+
+def user_data_path(project_name: str) -> Path:
+	system = platform.system()
+	if system == "Darwin":
+		return Path.home() / "Library/Application Support/Godot/app_userdata" / project_name
+	if system == "Windows":
+		return Path(os.environ["APPDATA"]) / "Godot/app_userdata" / project_name
+	data_home = Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local/share"))
+	return data_home / "godot/app_userdata" / project_name
+
+
+def create_isolated_project(temp_root: Path, project_name: str) -> Path:
+	project_dir = temp_root / "project"
+	project_dir.mkdir()
+	project_text = (REPO_ROOT / "project.godot").read_text(encoding="utf-8")
+	project_text = re.sub(
+		r'config/name="[^"]*"', f'config/name="{project_name}"', project_text, count=1
+	)
+	(project_dir / "project.godot").write_text(project_text, encoding="utf-8")
+	(project_dir / "addons").symlink_to(REPO_ROOT / "addons", target_is_directory=True)
+	for asset_name in ("icon.svg", "icon.png", "TestScene.tscn"):
+		asset = REPO_ROOT / asset_name
+		if asset.exists():
+			(project_dir / asset_name).symlink_to(asset)
+	return project_dir
+
+
+def initialize(host: str, port: int, token: str = "") -> tuple[int, dict]:
+	payload = json.dumps(
+		{
+			"jsonrpc": "2.0",
+			"method": "initialize",
+			"params": {
+				"protocolVersion": "2025-03-26",
+				"capabilities": {},
+				"clientInfo": {"name": "dual-loopback-test", "version": "1.0"},
+			},
+			"id": 1,
+		}
+	).encode("utf-8")
+	headers = {"Content-Type": "application/json", "Content-Length": str(len(payload))}
+	if token:
+		headers["Authorization"] = f"Bearer {token}"
+	connection = http.client.HTTPConnection(host, port, timeout=3)
+	try:
+		connection.request("POST", "/mcp", body=payload, headers=headers)
+		response = connection.getresponse()
+		body = response.read().decode("utf-8")
+		try:
+			payload = json.loads(body)
+		except json.JSONDecodeError:
+			payload = {}
+		return response.status, payload
+	finally:
+		connection.close()
+
+
+class GodotServer:
+	def __init__(
+		self, *, port: int, expect_ready: bool = True, settings: dict[str, object] | None = None
+	) -> None:
+		self.port = port
+		self.expect_ready = expect_ready
+		self.settings = settings or {}
+		self.temp_root: Path | None = None
+		self.project_name = f"GodotMcpDualLoopback-{uuid.uuid4().hex}"
+		self.project_dir: Path | None = None
+		self.user_dir = user_data_path(self.project_name)
+		self.log_path: Path | None = None
+		self.process: subprocess.Popen[str] | None = None
+		self.output = ""
+
+	def __enter__(self) -> "GodotServer":
+		godot_exe = Path(os.environ.get("GODOT_EXE", str(DEFAULT_GODOT_EXE)))
+		if not godot_exe.exists():
+			raise FileNotFoundError(f"Godot executable not found: {godot_exe}")
+		self.temp_root = Path(
+			tempfile.mkdtemp(prefix=".tmp_http_dual_loopback_", dir=REPO_ROOT / "test/integration")
+		)
+		self.project_dir = create_isolated_project(self.temp_root, self.project_name)
+		self.log_path = self.temp_root / "godot.log"
+		if self.settings:
+			self.user_dir.mkdir(parents=True)
+			settings_lines = ["[meta]", "version=1", "", "[settings]"]
+			for key, value in self.settings.items():
+				serialized = json.dumps(value).lower() if isinstance(value, bool) else json.dumps(value)
+				settings_lines.append(f"{key}={serialized}")
+			(self.user_dir / "mcp_settings.cfg").write_text(
+				"\n".join(settings_lines) + "\n", encoding="utf-8"
+			)
+		self.process = subprocess.Popen(
+			[
+				str(godot_exe),
+				"--editor",
+				"--headless",
+				"--path",
+				str(self.project_dir),
+				"--log-file",
+				str(self.log_path),
+				"--",
+				"--mcp-server",
+				f"--mcp-port={self.port}",
+			],
+			cwd=self.project_dir,
+			stdout=subprocess.PIPE,
+			stderr=subprocess.STDOUT,
+			text=True,
+		)
+		if self.expect_ready:
+			self.wait_until_ready()
+		return self
+
+	def wait_until_ready(self, timeout_seconds: float = 30.0) -> None:
+		deadline = time.monotonic() + timeout_seconds
+		last_error: Exception | None = None
+		while time.monotonic() < deadline:
+			if self.process is not None and self.process.poll() is not None:
+				break
+			try:
+				token = str(self.settings.get("auth_token", ""))
+				status, payload = initialize("127.0.0.1", self.port, token)
+				if status == 200 and payload.get("result"):
+					return
+			except (OSError, ValueError) as error:
+				last_error = error
+			time.sleep(0.2)
+		self._collect_output()
+		raise TimeoutError(
+			f"Timed out waiting for Godot MCP server: {last_error}\nGodot output:\n{self.output}"
+		)
+
+	def wait_until_start_failed(self, timeout_seconds: float = 30.0) -> None:
+		deadline = time.monotonic() + timeout_seconds
+		while time.monotonic() < deadline:
+			if self.log_path is not None and self.log_path.exists():
+				log_text = self.log_path.read_text(encoding="utf-8", errors="replace")
+				if "Failed to listen on" in log_text:
+					return
+			if self.process is not None and self.process.poll() is not None:
+				break
+			time.sleep(0.1)
+		self._collect_output()
+		raise TimeoutError(f"Godot did not report a bind failure\nGodot output:\n{self.output}")
+
+	def _collect_output(self) -> None:
+		if self.process is None or self.process.stdout is None:
+			return
+		if self.process.poll() is None:
+			return
+		self.output = self.process.stdout.read()
+
+	def __exit__(self, exc_type, exc_value, traceback) -> None:
+		if self.process is not None and self.process.poll() is None:
+			self.process.terminate()
+			try:
+				self.process.wait(timeout=10)
+			except subprocess.TimeoutExpired:
+				self.process.kill()
+				self.process.wait(timeout=5)
+		self._collect_output()
+		if self.process is not None and self.process.stdout is not None:
+			self.process.stdout.close()
+		if self.temp_root is not None:
+			shutil.rmtree(self.temp_root, ignore_errors=True)
+		shutil.rmtree(self.user_dir, ignore_errors=True)
+
+
+class HttpDualLoopbackBindingTest(unittest.TestCase):
+	def test_local_mode_serves_both_loopbacks_and_rejects_lan(self) -> None:
+		lan_address = find_non_loopback_ipv4()
+		self.assertTrue(lan_address, "A non-loopback IPv4 address is required for this test")
+		port = find_free_port()
+		with GodotServer(port=port):
+			ipv4_status, ipv4_payload = initialize("127.0.0.1", port)
+			self.assertEqual(200, ipv4_status)
+			self.assertIn("result", ipv4_payload)
+
+			ipv6_status, ipv6_payload = initialize("::1", port)
+			self.assertEqual(200, ipv6_status)
+			self.assertIn("result", ipv6_payload)
+
+			with self.assertRaises(OSError):
+				initialize(lan_address, port)
+
+	def test_lan_only_port_owner_does_not_block_local_loopback_listeners(self) -> None:
+		lan_address = find_non_loopback_ipv4()
+		self.assertTrue(lan_address, "A non-loopback IPv4 address is required for this test")
+		with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as lan_listener:
+			lan_listener.bind((lan_address, 0))
+			lan_listener.listen()
+			port = int(lan_listener.getsockname()[1])
+			with GodotServer(port=port):
+				ipv4_status, _ = initialize("127.0.0.1", port)
+				ipv6_status, _ = initialize("::1", port)
+				self.assertEqual(200, ipv4_status)
+				self.assertEqual(200, ipv6_status)
+
+	def test_one_loopback_bind_failure_rolls_back_the_other_listener(self) -> None:
+		with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as ipv6_listener:
+			ipv6_listener.bind(("::1", 0))
+			ipv6_listener.listen()
+			port = int(ipv6_listener.getsockname()[1])
+			with GodotServer(port=port, expect_ready=False) as server:
+				server.wait_until_start_failed()
+				with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+					probe.settimeout(1)
+					with self.assertRaises(OSError):
+						probe.connect(("127.0.0.1", port))
+
+	def test_remote_mode_accepts_lan_and_enforces_bearer_auth(self) -> None:
+		lan_address = find_non_loopback_ipv4()
+		self.assertTrue(lan_address, "A non-loopback IPv4 address is required for this test")
+		port = find_free_port()
+		token = "dual-loopback-test-token"
+		with GodotServer(
+			port=port,
+			settings={"allow_remote": True, "auth_enabled": True, "auth_token": token},
+		):
+			unauthorized_status, _ = initialize(lan_address, port)
+			self.assertEqual(401, unauthorized_status)
+			authorized_status, payload = initialize(lan_address, port, token)
+			self.assertEqual(200, authorized_status)
+			self.assertIn("result", payload)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/test/unit/test_mcp_http_server.gd
+++ b/test/unit/test_mcp_http_server.gd
@@ -91,6 +91,22 @@ func test_set_remote_config():
 	assert_eq(_http_server._allow_remote, true, "Allow remote should be true")
 	assert_eq(_http_server._cors_origin, "http://localhost:3000", "CORS origin should be set")
 
+func test_bind_addresses_cover_both_local_ip_families():
+	_http_server.set_remote_config(false, "*")
+	assert_eq(
+		_http_server._get_bind_addresses(),
+		PackedStringArray(["127.0.0.1", "::1"]),
+		"Local mode should bind both IPv4 and IPv6 loopback"
+	)
+
+func test_remote_bind_address_covers_all_interfaces():
+	_http_server.set_remote_config(true, "*")
+	assert_eq(
+		_http_server._get_bind_addresses(),
+		PackedStringArray(["*"]),
+		"Remote mode should bind all interfaces"
+	)
+
 func test_max_request_size_constant():
 	assert_eq(_http_server.MAX_REQUEST_SIZE, 1024 * 1024, "Max request size should be 1MB")
 

--- a/test/unit/test_mcp_server_core.gd
+++ b/test/unit/test_mcp_server_core.gd
@@ -197,6 +197,22 @@ func test_set_rate_limit():
 func test_is_running_initially():
 	assert_false(_core.is_running(), "Should not be running initially")
 
+func test_http_transport_replays_cached_remote_config_when_recreated():
+	_core.set_transport_type(_core.TransportType.TRANSPORT_HTTP)
+	_core.set_remote_config(true, "https://example.test")
+	assert_true(_core._init_transport(), "HTTP transport should initialize")
+	assert_true(_core._transport._allow_remote, "Recreated transport should allow remote access")
+	assert_eq(
+		_core._transport._cors_origin,
+		"https://example.test",
+		"Recreated transport should preserve the configured CORS origin"
+	)
+	_core._transport = null
+	_core.set_remote_config(false, "https://local.test")
+	assert_true(_core._init_transport(), "Replacement HTTP transport should initialize")
+	assert_false(_core._transport._allow_remote, "Replacement transport should use current local mode")
+	assert_eq(_core._transport._cors_origin, "https://local.test")
+
 func test_protocol_version_constant():
 	assert_eq(MCPTypes.PROTOCOL_VERSION, "2025-11-25", "Protocol version should be 2025-11-25")
 

--- a/test/unit/test_mcp_server_native.gd
+++ b/test/unit/test_mcp_server_native.gd
@@ -1,5 +1,26 @@
 extends "res://addons/gut/test.gd"
 
+class FakeServer:
+	extends RefCounted
+	var transport_type: int = -1
+	var port: int = -1
+	var remote_allowed: bool = false
+	var cors_origin: String = ""
+	var auth_manager: RefCounted = null
+
+	func set_transport_type(value: int) -> void:
+		transport_type = value
+
+	func set_http_port(value: int) -> void:
+		port = value
+
+	func set_remote_config(value: bool, origin: String) -> void:
+		remote_allowed = value
+		cors_origin = origin
+
+	func set_auth_manager(value: RefCounted) -> void:
+		auth_manager = value
+
 var _plugin_script: GDScript = null
 
 func before_each():
@@ -21,6 +42,38 @@ func _get_function_source(function_name: String) -> String:
 
 func test_plugin_script_loads():
 	assert_ne(_plugin_script, null, "Plugin script should load successfully")
+
+func test_start_config_sync_uses_current_remote_and_auth_values():
+	var server := FakeServer.new()
+
+	_plugin_script.sync_server_start_config(
+		server,
+		"http",
+		19123,
+		true,
+		"https://example.test",
+		true,
+		"current-auth-token-123"
+	)
+
+	assert_eq(server.transport_type, MCPServerCore.TransportType.TRANSPORT_HTTP)
+	assert_eq(server.port, 19123)
+	assert_true(server.remote_allowed)
+	assert_eq(server.cors_origin, "https://example.test")
+	assert_not_null(server.auth_manager, "Current auth settings should create a manager")
+	assert_true(
+		server.auth_manager.validate_request({"authorization": "Bearer current-auth-token-123"}),
+		"The synchronized manager should use the current token"
+	)
+
+func test_start_config_sync_clears_stale_auth_manager():
+	var server := FakeServer.new()
+	server.auth_manager = McpAuthManager.new()
+
+	_plugin_script.sync_server_start_config(server, "http", 9080, false, "*", false, "")
+
+	assert_null(server.auth_manager, "Disabled auth should clear a manager from an earlier start")
+	assert_false(server.remote_allowed, "Each start should also apply the current remote setting")
 
 func test_plugin_has_enter_tree():
 	assert_true(_plugin_script.has_method("_enter_tree") or _plugin_script.get_script_method_list().any(func(m): return m.name == "_enter_tree"), "Should have _enter_tree method")


### PR DESCRIPTION
## Summary

- bind local-only HTTP mode to both 127.0.0.1 and ::1
- keep IPv4 and IPv6 loopback connections on one accept thread and one shared MCP/session/auth state
- bind all available interfaces only when allow_remote is enabled
- treat the actual address-specific listen calls as the authority instead of rejecting startup through a port-wide preflight
- roll back every listener atomically when any required loopback bind fails
- cache and replay remote/CORS settings when the HTTP transport is recreated
- synchronize the final command-line transport/port and current remote/auth settings before every server start

This supersedes #71 and addresses both automated review findings there:

1. localhost remains reachable through IPv4 and IPv6 loopback.
2. a process listening on the same port only on a LAN address no longer blocks loopback listeners that can coexist with it.

## TDD evidence

RED against origin/main:

- local mode accepted a request through the machine LAN address because TCPServer.listen used the wildcard default
- remote mode failed to accept LAN traffic because allow_remote was set before transport creation and was not replayed
- plugin start configuration did not refresh current remote/auth values

GREEN integration results on Godot 4.6.2 / macOS:

    4/4 passed

Covered behavior:

- 127.0.0.1 initialize returns HTTP 200
- ::1 initialize returns HTTP 200
- default local mode refuses the LAN address
- a LAN-only listener on the same port does not block either loopback listener
- if ::1 is already occupied, startup fails and the earlier 127.0.0.1 listener is rolled back
- remote mode accepts LAN traffic and enforces bearer authentication: missing token 401, valid token 200

Command:

    GODOT_EXE=/Applications/Godot-4.6.2.app/Contents/MacOS/Godot python3 test/integration/test_http_dual_loopback_binding.py -v

Focused GUT additions pass:

- HTTP listener policy: 24/24 related tests
- core remote/CORS replay: 1/1
- plugin start configuration synchronization: 2/2

The full GUT run on this branch reported 690 tests, 645 passed, 27 failed, and 18 pending/risky. An isolated origin/main checkout reported the same 27 failures and 18 pending/risky; the five tests added by this change all pass.

Python compilation, Godot script parsing, and git diff --check pass.

## Remaining platform boundary

The real dual-bind integration was run on macOS with Godot 4.6.2. Windows and Linux were not exercised locally. If IPv6 loopback is unavailable, local mode intentionally fails atomically instead of silently degrading to IPv4-only.