### PR TITLE
fix(runtime): make probe polling exactly-once per tool call

### DIFF
--- a/addons/godot_mcp/tools/debug_tools_native.gd
+++ b/addons/godot_mcp/tools/debug_tools_native.gd
@@ -2874,7 +2874,7 @@ func _compare_values(actual: String, expected: String, operator: String) -> bool
 			return float(actual) <= float(expected)
 	return false
 
-func _request_runtime_probe(command: String, payload: Array, response_messages: Array, params: Dictionary, match_fields: Dictionary = {}) -> Dictionary:
+func _request_runtime_probe(command: String, payload: Array, response_messages: Array, params: Dictionary, match_fields: Dictionary = {}, allow_send: bool = true) -> Dictionary:
 	var bridge: RefCounted = _get_debugger_bridge()
 	if not bridge:
 		return {"error": "Debugger bridge is not available"}
@@ -2887,6 +2887,8 @@ func _request_runtime_probe(command: String, payload: Array, response_messages: 
 	if pending_entry.is_empty() or now_ms > int(pending_entry.get("expires_at_ms", 0)):
 		if not pending_entry.is_empty():
 			_pending_runtime_probe_requests.erase(request_key)
+		if not allow_send:
+			return {"status": "timeout", "response_messages": response_messages}
 		var baseline_sequence: int = bridge.get_message_sequence() if bridge.has_method("get_message_sequence") else 0
 		var refresh_result: Dictionary = bridge.send_debugger_message("mcp:" + command, payload, session_id)
 		if refresh_result.has("error"):
@@ -2953,10 +2955,7 @@ func _extract_pending_runtime_probe_response(bridge: RefCounted, pending_entry: 
 			return {"status": "success", "value": runtime_payload}
 
 	# No fresh response yet. Return pending so the poll loop keeps waiting for the
-	# newly-sent probe response. The eager stale fallback that lived here caused
-	# repeated identical expressions to return "stale" immediately, which the poll
-	# loop treated as retryable, burning the full timeout window on every call.
-	# Stale fallback now happens only after the poll loop times out.
+	# response to the command already sent by this invocation.
 	return {}
 
 func _request_runtime_probe_poll(
@@ -2988,26 +2987,15 @@ func _request_runtime_probe_poll(
 				await tree.process_frame
 			else:
 				OS.delay_msec(16)
-			result = _request_runtime_probe(command, payload, response_messages, params, match_fields)
+			result = _request_runtime_probe(command, payload, response_messages, params, match_fields, false)
 			if result.get("status") not in ["pending", "stale"]:
 				break
-	# Timeout expired without a fresh response. Fall back to the latest cached
-	# payload matching the request (if any) so callers still get data rather than
-	# an empty result. This is the only place stale data is served now.
+	# A timeout is an unknown outcome. Never resend the command or promote cached
+	# data to success for the current invocation.
 	if result.get("status") in ["pending", "stale"]:
-		for message_name in response_messages:
-			var cached_payload: Variant = bridge.get_latest_message_payload(message_name, match_fields) if bridge else null
-			if cached_payload is Dictionary:
-				result = cached_payload.duplicate(true)
-				result["status"] = "success"
-				result["from_cache"] = true
-				result["stale"] = true
-				return result
-			if cached_payload != null:
-				return {"status": "success", "from_cache": true, "stale": true, "value": cached_payload}
-		# No cached payload either - return the pending status as-is
-		result["status"] = "timeout"
-		return result
+		var request_key: String = _make_runtime_probe_request_key(command, payload, int(params.get("session_id", -1)), response_messages, match_fields)
+		_pending_runtime_probe_requests.erase(request_key)
+		return {"status": "timeout", "response_messages": response_messages}
 	return result
 
 func _is_truthy_runtime_value(value: Variant) -> bool:

--- a/test/unit/tools/test_debug_tools.gd
+++ b/test/unit/tools/test_debug_tools.gd
@@ -39,6 +39,32 @@ class FakeRuntimeBridge:
 			return latest_payload
 		return null
 
+class TimeoutRuntimeBridge:
+	extends RefCounted
+
+	var send_count: int = 0
+	var cached_payload: Dictionary = {
+		"fps": 30.0,
+		"current_scene": "/root/StaleScene",
+		"node_count": 99
+	}
+
+	func get_message_sequence() -> int:
+		return 0
+
+	func send_debugger_message(message: String, data: Array, session_id: int = -1) -> Dictionary:
+		send_count += 1
+		return {"status": "success", "sessions_updated": 1}
+
+	func get_captured_messages(count: int = 100, offset: int = 0, order: String = "desc") -> Dictionary:
+		return {"messages": [], "count": 0, "total_available": 0}
+
+	func get_captured_message_after_sequence(sequence: int, response_messages: Array, error_messages: Array = [], match_fields: Dictionary = {}) -> Dictionary:
+		return {}
+
+	func get_latest_message_payload(message: String, match_fields: Dictionary = {}) -> Variant:
+		return cached_payload
+
 class FakeRuntimePlugin:
 	extends RefCounted
 
@@ -181,37 +207,41 @@ func test_runtime_probe_polling_reuses_pending_request():
 	assert_eq(first_result.get("node_count"), 3, "Runtime info payload should come from the bridge response")
 	assert_eq(_runtime_bridge.send_count, 1, "First poll should send exactly one runtime probe message")
 
-	# Second call sends a new debugger message since the pending entry was consumed
+	# A second call sends once, but must not reuse the prior response as fresh evidence.
 	var second_result: Dictionary = await debug_tools._tool_get_runtime_info({"timeout_ms": 1500})
-	assert_eq(second_result.get("status"), "success", "Second call should return success (from cache or fresh)")
-	assert_eq(second_result.get("node_count"), 3, "Runtime info payload should come from the bridge response")
-	assert_eq(_runtime_bridge.send_count, 2, "Second call re-sends debugger message since first call consumed the pending entry")
+	assert_eq(second_result.get("status"), "timeout", "Second call should time out without a fresh response")
+	assert_false(second_result.has("node_count"), "Prior runtime data should not satisfy the second request")
+	assert_eq(_runtime_bridge.send_count, 2, "Each tool call should send one runtime probe message")
 
-func test_timeout_fallback_marks_stale():
-	var debug_tools_script: GDScript = load("res://addons/godot_mcp/tools/debug_tools_native.gd")
-	var source_code: String = debug_tools_script.source_code
-	# The stale fallback moved from _extract_pending_runtime_probe_response to
-	# _request_runtime_probe_poll after the poll loop times out.
-	# Verify the timeout handler sets from_cache + stale flags.
-	assert_true(source_code.contains('result["from_cache"] = true'), "Timeout fallback should mark from_cache")
-	assert_true(source_code.contains('result["stale"] = true'), "Timeout fallback should mark stale=true")
-	# The fresh path in _extract_pending_runtime_probe_response should still use "success"
-	assert_true(source_code.contains('response["status"] = "success"'), "Fresh response path should use success")
+func test_runtime_probe_timeout_sends_once_and_does_not_promote_cache():
+	var debug_tools: RefCounted = load("res://addons/godot_mcp/tools/debug_tools_native.gd").new()
+	_runtime_bridge = TimeoutRuntimeBridge.new()
+	Engine.set_meta("GodotMCPPlugin", FakeRuntimePlugin.new(_runtime_bridge))
 
-func test_poll_loop_continues_on_stale():
-	var debug_tools_script: GDScript = load("res://addons/godot_mcp/tools/debug_tools_native.gd")
-	var source_code: String = debug_tools_script.source_code
-	# The poll loop should continue when status is "stale" (not exit early)
-	assert_true(source_code.contains('not in ["pending", "stale"]'), "Poll loop should continue on stale status")
-	# Timeout fallback should convert stale to success with from_cache
-	assert_true(source_code.contains('result["status"] = "success"'), "Timeout should convert to success")
-	assert_true(source_code.contains('result["from_cache"] = true'), "Timeout should mark from_cache")
-	# Verify ordering: the from_cache mark should appear AFTER the poll loop
-	var poll_loop_pos: int = source_code.find('not in ["pending", "stale"]')
-	var from_cache_pos: int = source_code.find('result["from_cache"] = true')
-	assert_true(poll_loop_pos >= 0, "Poll loop condition should exist")
-	assert_true(from_cache_pos >= 0, "from_cache marker should exist")
-	assert_true(poll_loop_pos < from_cache_pos, "from_cache should be set AFTER poll loop completes")
+	var result: Dictionary = await debug_tools._tool_get_runtime_info({"timeout_ms": 1})
+
+	assert_eq(_runtime_bridge.send_count, 1, "One tool call should send one runtime probe message")
+	assert_eq(result.get("status"), "timeout", "Missing fresh evidence should remain a timeout")
+	assert_false(result.get("from_cache", false), "Timeout should not be promoted from cache")
+	assert_false(result.get("stale", false), "Timeout should not masquerade as stale success")
+	assert_false(result.has("node_count"), "Cached runtime data should not satisfy the timed-out request")
+	assert_true(debug_tools._pending_runtime_probe_requests.is_empty(), "Timed-out requests should be removed")
+
+func test_runtime_mutation_timeout_sends_exactly_once():
+	var debug_tools: RefCounted = load("res://addons/godot_mcp/tools/debug_tools_native.gd").new()
+	_runtime_bridge = TimeoutRuntimeBridge.new()
+	Engine.set_meta("GodotMCPPlugin", FakeRuntimePlugin.new(_runtime_bridge))
+
+	var result: Dictionary = await debug_tools._tool_create_runtime_node({
+		"parent_path": "/root/Main",
+		"node_type": "Node",
+		"node_name": "CreatedOnce",
+		"timeout_ms": 1
+	})
+
+	assert_eq(_runtime_bridge.send_count, 1, "A timed-out mutation must not be sent again")
+	assert_eq(result.get("status"), "timeout", "An unconfirmed mutation should remain a timeout")
+	assert_true(debug_tools._pending_runtime_probe_requests.is_empty(), "Timed-out mutations should be removed")
 
 func test_poll_loop_enters_on_initial_stale():
 	var debug_tools_script: GDScript = load("res://addons/godot_mcp/tools/debug_tools_native.gd")


### PR DESCRIPTION
## Summary

- send each runtime probe command at most once per MCP tool invocation
- return `timeout` when no fresh response arrives instead of promoting cached payloads to success
- add behavioral regression coverage for both read-only probes and non-idempotent runtime mutations

## Root cause

`_request_runtime_probe_poll()` repeatedly called `_request_runtime_probe()`. Once the pending entry expired, that helper sent the debugger command again. A timed-out non-idempotent tool such as `create_runtime_node` could therefore execute more than once.

After polling expired, the same path also returned the latest cached payload as `status: success` with `from_cache` and `stale` flags. That made an unknown current outcome look successful.

## Fix

The first poll call is the only call allowed to send. Subsequent iterations only inspect the response for that request. If no fresh response arrives, the pending entry is removed and the tool returns `status: timeout`; cached data is not used as evidence for the current invocation.

## Verification

- Focused GUT suite on Godot 4.7.1: 36/36 tests passed, 85 assertions
- Full unit baseline on unmodified `main`: 640 passing, 27 failing, 18 risky/pending
- Full unit suite on this branch: 641 passing, 26 failing, 18 risky/pending
- The only baseline failure removed is `test_runtime_probe_polling_reuses_pending_request`; no new failing test names were introduced
- `debug_tools_native.gd` passes Godot `--check-only`
- `git diff --check` passes

The remaining full-suite failures reproduce on unmodified `main` under the same Godot 4.7.1 environment.

## Scope

This PR does not change HTTP listener or authentication behavior. That work is already covered separately by #73, so this patch stays focused on runtime command delivery and timeout semantics.
